### PR TITLE
Make Athenian Yachts link clickable and reorder nav menu

### DIFF
--- a/__tests__/footer.test.tsx
+++ b/__tests__/footer.test.tsx
@@ -84,7 +84,10 @@ describe('Footer — Contact section', () => {
 
   test('renders Central Agent attribution with correct spelling', () => {
     render(<Footer />)
-    expect(screen.getByText('Central Agent : Athenian Yachts')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Athenian Yachts' })).toHaveAttribute(
+      'href',
+      'https://athenian-yachts.gr/'
+    )
   })
 })
 

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -64,7 +64,17 @@ export default function Footer() {
             </div>
             <div className="pt-4 border-t border-gray-700">
               <p className="text-sm text-gray-400">Athens, Greece</p>
-              <p className="text-sm text-blue-200 mt-1">Central Agent : Athenian Yachts</p>
+              <p className="text-sm text-blue-200 mt-1">
+                Central Agent :{' '}
+                <a
+                  href="https://athenian-yachts.gr/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-white transition-colors duration-200 underline"
+                >
+                  Athenian Yachts
+                </a>
+              </p>
             </div>
           </div>
         </div>

--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -29,9 +29,9 @@ export default function Navigation() {
   const router = useRouter();
 
   const navLinks = [
-    { href: '/experiences', label: 'Experiences', bold: true },
     { href: '/blueone',     label: 'The Yacht',   bold: true },
     { href: '/destinations',label: 'Destinations',bold: false },
+    { href: '/experiences', label: 'Experiences', bold: true },
     { href: '/about',       label: 'About',       bold: false },
     { href: '/availability',label: 'Availability',bold: false },
     { href: '/reviews',     label: 'Reviews',     bold: false },

--- a/app/contact/ContactClient.tsx
+++ b/app/contact/ContactClient.tsx
@@ -180,7 +180,7 @@ export default function ContactClient() {
                   </svg>
                 </div>
                 <p className="text-sm text-gray-500 mb-1">Central Agent</p>
-                <a href="https://athenian-yachts.gr" target="_blank" rel="noopener noreferrer" className="text-blue-600 font-semibold hover:text-blue-800 transition-colors">
+                <a href="https://athenian-yachts.gr/" target="_blank" rel="noopener noreferrer" className="text-blue-600 font-semibold hover:text-blue-800 transition-colors">
                   Athenian Yachts
                 </a>
               </div>


### PR DESCRIPTION
## Summary
This PR makes the Athenian Yachts central agent attribution clickable by converting it to a hyperlink, ensures URL consistency across components, and reorders the navigation menu for improved UX.

## Key Changes

- **Footer component**: Converted "Athenian Yachts" text to a clickable link (`https://athenian-yachts.gr/`) with hover styling and accessibility attributes (`target="_blank"`, `rel="noopener noreferrer"`)
- **Contact page**: Added trailing slash to Athenian Yachts URL for consistency (`https://athenian-yachts.gr/`)
- **Navigation menu**: Reordered nav links to prioritize "The Yacht" first, followed by "Destinations", then "Experiences" (moved from first position)
- **Footer test**: Updated test to verify the link renders correctly with proper `href` attribute instead of checking for plain text

## Implementation Details

- The Footer link uses Tailwind classes for styling: `hover:text-white transition-colors duration-200 underline`
- Both Footer and Contact components now reference the same URL with consistent formatting
- Navigation reordering improves information hierarchy by leading with the yacht specification before experiences

https://claude.ai/code/session_01BKanAANy1Lxgi9Ex1omZ4Z