### PR TITLE
Add client holiday preparation space

### DIFF
--- a/__tests__/client-space-summary.test.tsx
+++ b/__tests__/client-space-summary.test.tsx
@@ -537,7 +537,7 @@ describe('SummaryClient — Food section with data', () => {
   it('renders seafood likes', async () => {
     renderSummary();
     await waitFor(() => {
-      expect(screen.getByText('Grilled fish')).toBeInTheDocument();
+      expect(screen.getAllByText('Grilled fish').length).toBeGreaterThan(0);
     });
   });
 

--- a/__tests__/client-space-summary.test.tsx
+++ b/__tests__/client-space-summary.test.tsx
@@ -406,27 +406,44 @@ describe('SummaryClient — Crew section with data', () => {
   });
 });
 
-describe('SummaryClient — Travel section with data', () => {
-  const prepWithTravel = {
+describe('SummaryClient — Travel section with groups (new UI)', () => {
+  const prepWithGroups = {
     ...mockPrep,
+    crew: [
+      { firstName: 'Alice', lastName: 'Smith' },
+      { firstName: 'Bob', lastName: 'Smith' },
+    ],
     travel: {
-      arrivalDate: '2026-06-30',
-      arrivalFlight: 'BA123',
-      arrivalTime: '14:30',
-      stayingAtHotel: true,
-      hotelName: 'Grand Hotel Athens',
-      transferFromAirport: true,
-      departureDate: '2026-07-09',
-      departureFlight: 'BA456',
+      groups: [
+        {
+          id: 'g1',
+          memberIndices: [0, 1],
+          arrivalDate: '2026-06-30',
+          arrivalFlight: 'BA123',
+          arrivalTime: '14:30',
+          stayingAtHotel: true,
+          hotelName: 'Grand Hotel Athens',
+          transferFromAirport: true,
+          departureDate: '2026-07-09',
+          departureFlight: 'BA456',
+        },
+      ],
     },
   };
 
   beforeEach(() => {
-    mockGetClientPreparation.mockResolvedValue(prepWithTravel);
+    mockGetClientPreparation.mockResolvedValue(prepWithGroups);
     mockGetCharterByToken.mockResolvedValue(mockCharter);
   });
 
-  it('renders Arrival subsection', async () => {
+  it('renders group subsection with member names', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText(/group 1.*alice smith.*bob smith/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders Arrival sub-header', async () => {
     renderSummary();
     await waitFor(() => {
       expect(screen.getByText('Arrival')).toBeInTheDocument();
@@ -450,16 +467,45 @@ describe('SummaryClient — Travel section with data', () => {
   it('renders "Yes" for airport transfer', async () => {
     renderSummary();
     await waitFor(() => {
-      // BoolRow renders "Yes" for true
       const yesValues = screen.getAllByText('Yes');
       expect(yesValues.length).toBeGreaterThan(0);
     });
   });
 
-  it('renders Departure subsection', async () => {
+  it('renders Departure sub-header', async () => {
     renderSummary();
     await waitFor(() => {
       expect(screen.getByText('Departure')).toBeInTheDocument();
+    });
+  });
+
+  it('renders departure flight', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('BA456')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SummaryClient — Travel section with legacy flat fields', () => {
+  const prepWithLegacyTravel = {
+    ...mockPrep,
+    travel: {
+      arrivalDate: '2026-06-30',
+      arrivalFlight: 'EZ999',
+      departureDate: '2026-07-09',
+    },
+  };
+
+  beforeEach(() => {
+    mockGetClientPreparation.mockResolvedValue(prepWithLegacyTravel);
+    mockGetCharterByToken.mockResolvedValue(mockCharter);
+  });
+
+  it('renders flight number from legacy data', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('EZ999')).toBeInTheDocument();
     });
   });
 });

--- a/__tests__/client-space-summary.test.tsx
+++ b/__tests__/client-space-summary.test.tsx
@@ -1,0 +1,721 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mock Next.js modules
+// ---------------------------------------------------------------------------
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn().mockReturnValue({ push: jest.fn() }),
+  useSearchParams: jest.fn().mockReturnValue({ get: jest.fn() }),
+  usePathname: jest.fn().mockReturnValue('/client-space/test-token/summary'),
+}));
+
+jest.mock('next/image', () =>
+  function MockImage({ src, alt, ...rest }: { src: string; alt: string; [key: string]: unknown }) {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={src} alt={alt} {...rest} />;
+  }
+);
+
+// ---------------------------------------------------------------------------
+// Mock Firebase
+// ---------------------------------------------------------------------------
+jest.mock('../lib/firebase', () => ({ db: {}, storage: {} }));
+
+// ---------------------------------------------------------------------------
+// Mock marinas-data
+// ---------------------------------------------------------------------------
+jest.mock('../app/marinas-data', () => ({
+  getMarinaById: jest.fn().mockReturnValue({ id: 'ATH', name: 'Alimos Marina' }),
+  marinasByRegion: [],
+  DEFAULT_MARINA_ID: 'ATH',
+}));
+
+// ---------------------------------------------------------------------------
+// Mock lib/clientSpace
+// ---------------------------------------------------------------------------
+const mockToken = 'abc123';
+
+const mockCharter = {
+  id: 'charter-1',
+  name: 'Smith Family',
+  email: 'smith@example.com',
+  phone: '+1 555 1234',
+  startDate: '2026-07-01',
+  endDate: '2026-07-08',
+  boat: 'Fountaine Pajot Aura 51',
+  passengers: 4,
+  deliveryPoint: 'ATH',
+  redeliveryPoint: 'ATH',
+  embarkationPoint: 'ATH',
+  clientSpaceToken: mockToken,
+  status: 'confirmed' as const,
+  selectedTheme: 'Island Hopping',
+  holidayDescription: 'Anniversary trip',
+};
+
+const mockPrep = {
+  token: mockToken,
+  charterId: 'charter-1',
+  lastSavedStep: 0,
+  crew: [],
+  travel: {},
+  activities: {},
+  food: {},
+  beverages: {},
+  special: {},
+  checklist: {},
+  createdAt: null,
+  updatedAt: null,
+};
+
+const mockGetClientPreparation = jest.fn().mockResolvedValue(mockPrep);
+const mockGetCharterByToken = jest.fn().mockResolvedValue(mockCharter);
+
+jest.mock('../lib/clientSpace', () => ({
+  getClientPreparation: (...args: unknown[]) => mockGetClientPreparation(...args),
+  getCharterByClientSpaceToken: (...args: unknown[]) => mockGetCharterByToken(...args),
+  saveCrew: jest.fn().mockResolvedValue(undefined),
+  saveTravel: jest.fn().mockResolvedValue(undefined),
+  saveActivities: jest.fn().mockResolvedValue(undefined),
+  saveFood: jest.fn().mockResolvedValue(undefined),
+  saveBeverages: jest.fn().mockResolvedValue(undefined),
+  saveSpecial: jest.fn().mockResolvedValue(undefined),
+  saveChecklist: jest.fn().mockResolvedValue(undefined),
+  saveStep: jest.fn().mockResolvedValue(undefined),
+  saveSnapshot: jest.fn().mockResolvedValue(undefined),
+  getHistory: jest.fn().mockResolvedValue([]),
+  restoreSnapshot: jest.fn().mockResolvedValue(undefined),
+  CHECKLIST_CATEGORIES: [
+    {
+      id: 'documents',
+      label: 'Documents',
+      items: [
+        { id: 'doc-passport', label: 'Passport valid for 6+ months' },
+        { id: 'doc-insurance', label: 'Travel insurance arranged' },
+      ],
+    },
+    {
+      id: 'packing',
+      label: 'Clothing & Packing',
+      items: [
+        { id: 'pack-swimwear', label: 'Swimwear packed' },
+      ],
+    },
+  ],
+}));
+
+// ---------------------------------------------------------------------------
+// Mock lib/availability
+// ---------------------------------------------------------------------------
+jest.mock('../lib/availability', () => ({
+  getAllCharters: jest.fn().mockResolvedValue([]),
+  updateCharter: jest.fn().mockResolvedValue(undefined),
+  CHARTER_STATUS_LABEL: {},
+  CHARTER_STATUS_PRIORITY: {},
+  proposalRef: jest.fn().mockReturnValue('REF-001'),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock window.print
+// ---------------------------------------------------------------------------
+const mockPrint = jest.fn();
+Object.defineProperty(window, 'print', { value: mockPrint, writable: true });
+
+// ---------------------------------------------------------------------------
+// Import component AFTER mocks
+// ---------------------------------------------------------------------------
+import SummaryClient from '../app/client-space/[token]/summary/SummaryClient';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function renderSummary(token = mockToken) {
+  return render(<SummaryClient token={token} />);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SummaryClient — loading state', () => {
+  it('shows loading indicator while fetching', () => {
+    // Never resolve
+    mockGetClientPreparation.mockReturnValueOnce(new Promise(() => {}));
+    mockGetCharterByToken.mockReturnValueOnce(new Promise(() => {}));
+    renderSummary();
+    expect(screen.getByText(/loading summary/i)).toBeInTheDocument();
+  });
+});
+
+describe('SummaryClient — not-found state', () => {
+  it('shows not-found when charter is null', async () => {
+    mockGetCharterByToken.mockResolvedValueOnce(null);
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText(/summary not found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows not-found when prep is null', async () => {
+    mockGetClientPreparation.mockResolvedValueOnce(null);
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText(/summary not found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows not-found on fetch error', async () => {
+    mockGetCharterByToken.mockRejectedValueOnce(new Error('network'));
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText(/summary not found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows contact email in not-found state', async () => {
+    mockGetCharterByToken.mockResolvedValueOnce(null);
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText(/contact us at/i)).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SummaryClient — screen header', () => {
+  beforeEach(() => {
+    mockGetClientPreparation.mockResolvedValue(mockPrep);
+    mockGetCharterByToken.mockResolvedValue(mockCharter);
+  });
+
+  it('renders BlueOne logo', async () => {
+    renderSummary();
+    await waitFor(() => {
+      const logo = screen.getByAltText('BlueOne');
+      expect(logo).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Preference Summary" title', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Preference Summary')).toBeInTheDocument();
+    });
+  });
+
+  it('shows client name and charter start date in header', async () => {
+    renderSummary();
+    await waitFor(() => {
+      const matches = screen.getAllByText(/smith family/i);
+      expect(matches.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('renders Edit Preferences link pointing to /client-space/{token}', async () => {
+    renderSummary();
+    await waitFor(() => {
+      const link = screen.getByText(/edit preferences/i).closest('a');
+      expect(link).toHaveAttribute('href', `/client-space/${mockToken}`);
+    });
+  });
+
+  it('renders Print / Save PDF button', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /print \/ save pdf/i })).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SummaryClient — PDF / print', () => {
+  beforeEach(() => {
+    mockPrint.mockClear();
+    mockGetClientPreparation.mockResolvedValue(mockPrep);
+    mockGetCharterByToken.mockResolvedValue(mockCharter);
+  });
+
+  it('calls window.print() when Print button is clicked', async () => {
+    renderSummary();
+    const btn = await screen.findByRole('button', { name: /print \/ save pdf/i });
+    fireEvent.click(btn);
+    expect(mockPrint).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SummaryClient — section titles', () => {
+  beforeEach(() => {
+    mockGetClientPreparation.mockResolvedValue(mockPrep);
+    mockGetCharterByToken.mockResolvedValue(mockCharter);
+  });
+
+  const sections = [
+    'Charter Details',
+    'Crew / Passenger Details',
+    'Travel & Logistics',
+    'Activities & Health',
+    'Food Preferences',
+    'Beverages & Bar',
+    'Special Requests',
+  ];
+
+  sections.forEach(title => {
+    it(`renders "${title}" section`, async () => {
+      renderSummary();
+      await waitFor(() => {
+        expect(screen.getByText(title)).toBeInTheDocument();
+      });
+    });
+  });
+
+  it('renders checklist section with progress count', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText(/pre-departure checklist/i)).toBeInTheDocument();
+      expect(screen.getByText(/0 \/ 3 completed/i)).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SummaryClient — empty state messages', () => {
+  beforeEach(() => {
+    mockGetClientPreparation.mockResolvedValue(mockPrep);
+    mockGetCharterByToken.mockResolvedValue(mockCharter);
+  });
+
+  it('shows empty message for crew', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('No crew details submitted yet.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty message for travel', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('No travel details submitted yet.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty message for activities', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('No activity or health details submitted yet.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty message for food', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('No food preferences submitted yet.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty message for beverages', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('No beverage preferences submitted yet.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty message for special requests', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('No special requests submitted yet.')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SummaryClient — Charter Details section', () => {
+  beforeEach(() => {
+    mockGetClientPreparation.mockResolvedValue(mockPrep);
+    mockGetCharterByToken.mockResolvedValue(mockCharter);
+  });
+
+  it('renders vessel name', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Fountaine Pajot Aura 51')).toBeInTheDocument();
+    });
+  });
+
+  it('renders guest count', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('4 passengers')).toBeInTheDocument();
+    });
+  });
+
+  it('renders marina name from getMarinaById', async () => {
+    renderSummary();
+    await waitFor(() => {
+      // getMarinaById returns 'Alimos Marina'
+      const marinaLabels = screen.getAllByText('Alimos Marina');
+      expect(marinaLabels.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('renders experience theme', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Island Hopping')).toBeInTheDocument();
+    });
+  });
+
+  it('renders holiday description', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Anniversary trip')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SummaryClient — Crew section with data', () => {
+  const prepWithCrew = {
+    ...mockPrep,
+    crew: [
+      { firstName: 'Alice', lastName: 'Smith', gender: 'Female', nationality: 'British', passportNumber: 'AB123456', dateOfBirth: '1985-03-15', dietaryRestrictions: 'Vegan', medicalNotes: 'None' },
+      { firstName: 'Bob', lastName: 'Smith', gender: 'Male', nationality: 'American' },
+    ],
+  };
+
+  beforeEach(() => {
+    mockGetClientPreparation.mockResolvedValue(prepWithCrew);
+    mockGetCharterByToken.mockResolvedValue(mockCharter);
+  });
+
+  it('renders passenger subsection headings', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText(/passenger 1.*alice smith/i)).toBeInTheDocument();
+      expect(screen.getByText(/passenger 2.*bob smith/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders passport number', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('AB123456')).toBeInTheDocument();
+    });
+  });
+
+  it('renders dietary restrictions', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Vegan')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SummaryClient — Travel section with data', () => {
+  const prepWithTravel = {
+    ...mockPrep,
+    travel: {
+      arrivalDate: '2026-06-30',
+      arrivalFlight: 'BA123',
+      arrivalTime: '14:30',
+      stayingAtHotel: true,
+      hotelName: 'Grand Hotel Athens',
+      transferFromAirport: true,
+      departureDate: '2026-07-09',
+      departureFlight: 'BA456',
+    },
+  };
+
+  beforeEach(() => {
+    mockGetClientPreparation.mockResolvedValue(prepWithTravel);
+    mockGetCharterByToken.mockResolvedValue(mockCharter);
+  });
+
+  it('renders Arrival subsection', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Arrival')).toBeInTheDocument();
+    });
+  });
+
+  it('renders flight number', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('BA123')).toBeInTheDocument();
+    });
+  });
+
+  it('renders hotel name', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Grand Hotel Athens')).toBeInTheDocument();
+    });
+  });
+
+  it('renders "Yes" for airport transfer', async () => {
+    renderSummary();
+    await waitFor(() => {
+      // BoolRow renders "Yes" for true
+      const yesValues = screen.getAllByText('Yes');
+      expect(yesValues.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('renders Departure subsection', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Departure')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SummaryClient — Food section with data', () => {
+  const prepWithFood = {
+    ...mockPrep,
+    food: {
+      seafood: { likes: 'Grilled fish', dislikes: 'Raw', allergies: '' },
+      breakfastStyle: ['light'],
+      breakfastItems: ['Croissant', 'Yogurt'],
+      lunchStyle: 'Light salads',
+      dinnerStyle: 'Fine dining',
+    },
+  };
+
+  beforeEach(() => {
+    mockGetClientPreparation.mockResolvedValue(prepWithFood);
+    mockGetCharterByToken.mockResolvedValue(mockCharter);
+  });
+
+  it('renders Food Categories subsection', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Food Categories')).toBeInTheDocument();
+    });
+  });
+
+  it('renders seafood likes', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Grilled fish')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Breakfast subsection', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Breakfast')).toBeInTheDocument();
+    });
+  });
+
+  it('renders breakfast style tag', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Light / Cold')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Lunch & Dinner subsection', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Lunch & Dinner')).toBeInTheDocument();
+    });
+  });
+
+  it('renders lunch style', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Light salads')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SummaryClient — Beverages section with data', () => {
+  const prepWithBeverages = {
+    ...mockPrep,
+    beverages: {
+      warmBeverages: ['Coffee', 'Tea'],
+      warmBeveragesOther: 'Herbal infusions',
+      sodas: {
+        'Coke 0.5 l': { qty: 12, preferredBrand: 'Coca-Cola' },
+      },
+      wines: {
+        'White Wine': { qty: 6, preferredBrand: 'Chardonnay' },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    mockGetClientPreparation.mockResolvedValue(prepWithBeverages);
+    mockGetCharterByToken.mockResolvedValue(mockCharter);
+  });
+
+  it('renders Hot Beverages subsection', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Hot Beverages')).toBeInTheDocument();
+    });
+  });
+
+  it('renders warm beverage selections as tags', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Coffee')).toBeInTheDocument();
+      expect(screen.getByText('Tea')).toBeInTheDocument();
+    });
+  });
+
+  it('renders other warm beverages', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Herbal infusions')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Sodas, Juices & Water subsection', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Sodas, Juices & Water')).toBeInTheDocument();
+    });
+  });
+
+  it('renders soda quantity', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('12')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Wines & Sparkling subsection', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Wines & Sparkling')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SummaryClient — Special Requests with data', () => {
+  const prepWithSpecial = {
+    ...mockPrep,
+    special: {
+      celebration: 'Wedding anniversary',
+      musicAtmosphere: 'Jazz and lounge',
+      petsOnBoard: 'Small dog',
+      extraNotes: 'Please have flowers on board',
+      emergencyContactName: 'Jane Smith',
+      emergencyContactPhone: '+1 555 9999',
+      emergencyContactRelation: 'Sister',
+    },
+  };
+
+  beforeEach(() => {
+    mockGetClientPreparation.mockResolvedValue(prepWithSpecial);
+    mockGetCharterByToken.mockResolvedValue(mockCharter);
+  });
+
+  it('renders celebration', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Wedding anniversary')).toBeInTheDocument();
+    });
+  });
+
+  it('renders music atmosphere', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Jazz and lounge')).toBeInTheDocument();
+    });
+  });
+
+  it('renders pets on board', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Small dog')).toBeInTheDocument();
+    });
+  });
+
+  it('renders emergency contact', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText(/jane smith/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders additional notes', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Please have flowers on board')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SummaryClient — Checklist section', () => {
+  beforeEach(() => {
+    mockGetCharterByToken.mockResolvedValue(mockCharter);
+  });
+
+  it('shows 0 / 3 completed when checklist is empty', async () => {
+    mockGetClientPreparation.mockResolvedValue(mockPrep);
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText(/0 \/ 3 completed/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows 2 / 3 completed when 2 items are checked', async () => {
+    const prepWithChecklist = {
+      ...mockPrep,
+      checklist: { 'doc-passport': true, 'doc-insurance': true },
+    };
+    mockGetClientPreparation.mockResolvedValue(prepWithChecklist);
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText(/2 \/ 3 completed/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders checklist category labels', async () => {
+    mockGetClientPreparation.mockResolvedValue(mockPrep);
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Documents')).toBeInTheDocument();
+      expect(screen.getByText('Clothing & Packing')).toBeInTheDocument();
+    });
+  });
+
+  it('renders individual checklist item labels', async () => {
+    mockGetClientPreparation.mockResolvedValue(mockPrep);
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Passport valid for 6+ months')).toBeInTheDocument();
+      expect(screen.getByText('Swimwear packed')).toBeInTheDocument();
+    });
+  });
+
+  it('shows checkmark for completed items', async () => {
+    const prepWithChecklist = {
+      ...mockPrep,
+      checklist: { 'doc-passport': true },
+    };
+    mockGetClientPreparation.mockResolvedValue(prepWithChecklist);
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('✓')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SummaryClient — footer', () => {
+  beforeEach(() => {
+    mockGetClientPreparation.mockResolvedValue(mockPrep);
+    mockGetCharterByToken.mockResolvedValue(mockCharter);
+  });
+
+  it('renders contact email in footer', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText(/blueone luxury yacht charters/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders confidentiality message', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText(/confidential.*blueone crew/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/client-space.test.tsx
+++ b/__tests__/client-space.test.tsx
@@ -1,0 +1,622 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ---------------------------------------------------------------------------
+// Mock Next.js modules
+// ---------------------------------------------------------------------------
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn().mockReturnValue({ push: jest.fn() }),
+  useSearchParams: jest.fn().mockReturnValue({ get: jest.fn() }),
+  usePathname: jest.fn().mockReturnValue('/client-space/test-token'),
+}));
+
+jest.mock('next/image', () =>
+  function MockImage({ src, alt, ...rest }: { src: string; alt: string; [key: string]: unknown }) {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={src} alt={alt} {...rest} />;
+  }
+);
+
+// ---------------------------------------------------------------------------
+// Mock Firebase
+// ---------------------------------------------------------------------------
+jest.mock('../lib/firebase', () => ({ db: {}, storage: {} }));
+
+// ---------------------------------------------------------------------------
+// Mock marinas-data
+// ---------------------------------------------------------------------------
+jest.mock('../app/marinas-data', () => ({
+  getMarinaById: jest.fn().mockReturnValue({ id: 'ATH', name: 'Alimos Marina' }),
+  marinasByRegion: [],
+  DEFAULT_MARINA_ID: 'ATH',
+}));
+
+// ---------------------------------------------------------------------------
+// Mock lib/clientSpace
+// ---------------------------------------------------------------------------
+const mockToken = 'abc123';
+
+const mockCharter = {
+  id: 'charter-1',
+  name: 'Smith Family',
+  startDate: '2026-07-01',
+  endDate: '2026-07-08',
+  boat: 'Fountaine Pajot Aura 51',
+  passengers: 4,
+  deliveryPoint: 'ATH',
+  redeliveryPoint: 'ATH',
+  clientSpaceToken: mockToken,
+  status: 'confirmed' as const,
+};
+
+const mockPrep = {
+  token: mockToken,
+  charterId: 'charter-1',
+  lastSavedStep: 0,
+  crew: [],
+  travel: {},
+  activities: {},
+  food: {},
+  beverages: {},
+  special: {},
+  checklist: {},
+  createdAt: null,
+  updatedAt: null,
+};
+
+const mockSaveCrew = jest.fn().mockResolvedValue(undefined);
+const mockSaveTravel = jest.fn().mockResolvedValue(undefined);
+const mockSaveActivities = jest.fn().mockResolvedValue(undefined);
+const mockSaveFood = jest.fn().mockResolvedValue(undefined);
+const mockSaveBeverages = jest.fn().mockResolvedValue(undefined);
+const mockSaveSpecial = jest.fn().mockResolvedValue(undefined);
+const mockSaveChecklist = jest.fn().mockResolvedValue(undefined);
+const mockSaveStep = jest.fn().mockResolvedValue(undefined);
+const mockSaveSnapshot = jest.fn().mockResolvedValue(undefined);
+const mockGetHistory = jest.fn().mockResolvedValue([]);
+const mockRestoreSnapshot = jest.fn().mockResolvedValue(undefined);
+const mockGetClientPreparation = jest.fn().mockResolvedValue(mockPrep);
+const mockGetCharterByToken = jest.fn().mockResolvedValue(mockCharter);
+
+jest.mock('../lib/clientSpace', () => ({
+  getClientPreparation: (...args: unknown[]) => mockGetClientPreparation(...args),
+  getCharterByClientSpaceToken: (...args: unknown[]) => mockGetCharterByToken(...args),
+  saveCrew: (...args: unknown[]) => mockSaveCrew(...args),
+  saveTravel: (...args: unknown[]) => mockSaveTravel(...args),
+  saveActivities: (...args: unknown[]) => mockSaveActivities(...args),
+  saveFood: (...args: unknown[]) => mockSaveFood(...args),
+  saveBeverages: (...args: unknown[]) => mockSaveBeverages(...args),
+  saveSpecial: (...args: unknown[]) => mockSaveSpecial(...args),
+  saveChecklist: (...args: unknown[]) => mockSaveChecklist(...args),
+  saveStep: (...args: unknown[]) => mockSaveStep(...args),
+  saveSnapshot: (...args: unknown[]) => mockSaveSnapshot(...args),
+  getHistory: (...args: unknown[]) => mockGetHistory(...args),
+  restoreSnapshot: (...args: unknown[]) => mockRestoreSnapshot(...args),
+  CHECKLIST_CATEGORIES: [
+    {
+      id: 'documents',
+      label: 'Documents',
+      items: [
+        { id: 'doc-passport', label: 'Passport valid for 6+ months' },
+        { id: 'doc-insurance', label: 'Travel insurance arranged' },
+      ],
+    },
+    {
+      id: 'packing',
+      label: 'Clothing & Packing',
+      items: [
+        { id: 'pack-swimwear', label: 'Swimwear packed' },
+      ],
+    },
+  ],
+}));
+
+// ---------------------------------------------------------------------------
+// Mock lib/availability (used indirectly)
+// ---------------------------------------------------------------------------
+jest.mock('../lib/availability', () => ({
+  getAllCharters: jest.fn().mockResolvedValue([]),
+  getMarinaById: jest.fn().mockReturnValue({ id: 'ATH', name: 'Alimos Marina' }),
+  updateCharter: jest.fn().mockResolvedValue(undefined),
+  CHARTER_STATUS_LABEL: {},
+  CHARTER_STATUS_PRIORITY: {},
+  proposalRef: jest.fn().mockReturnValue('REF-001'),
+}));
+
+// ---------------------------------------------------------------------------
+// Import component AFTER mocks
+// ---------------------------------------------------------------------------
+import ClientSpaceClient from '../app/client-space/[token]/ClientSpaceClient';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetClientPreparation.mockResolvedValue(mockPrep);
+  mockGetCharterByToken.mockResolvedValue(mockCharter);
+  mockSaveCrew.mockResolvedValue(undefined);
+  mockSaveTravel.mockResolvedValue(undefined);
+  mockSaveActivities.mockResolvedValue(undefined);
+  mockSaveFood.mockResolvedValue(undefined);
+  mockSaveBeverages.mockResolvedValue(undefined);
+  mockSaveSpecial.mockResolvedValue(undefined);
+  mockSaveChecklist.mockResolvedValue(undefined);
+  mockSaveStep.mockResolvedValue(undefined);
+  mockSaveSnapshot.mockResolvedValue(undefined);
+  mockGetHistory.mockResolvedValue([]);
+});
+
+async function renderAndWait() {
+  render(<ClientSpaceClient token={mockToken} />);
+  await waitFor(() => expect(screen.getByText('Holiday Preparation')).toBeInTheDocument());
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ClientSpaceClient — Loading & Error States', () => {
+  test('shows loading spinner initially', () => {
+    mockGetClientPreparation.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<ClientSpaceClient token={mockToken} />);
+    expect(screen.getByText(/loading your holiday space/i)).toBeInTheDocument();
+  });
+
+  test('shows not-found state when preparation is null', async () => {
+    mockGetClientPreparation.mockResolvedValue(null);
+    render(<ClientSpaceClient token={mockToken} />);
+    await waitFor(() => expect(screen.getByText(/link not found/i)).toBeInTheDocument());
+  });
+
+  test('shows not-found state when charter is null', async () => {
+    mockGetCharterByToken.mockResolvedValue(null);
+    render(<ClientSpaceClient token={mockToken} />);
+    await waitFor(() => expect(screen.getByText(/link not found/i)).toBeInTheDocument());
+  });
+
+  test('shows not-found state on fetch error', async () => {
+    mockGetClientPreparation.mockRejectedValue(new Error('Network error'));
+    render(<ClientSpaceClient token={mockToken} />);
+    await waitFor(() => expect(screen.getByText(/link not found/i)).toBeInTheDocument());
+  });
+});
+
+describe('ClientSpaceClient — Header & Navigation', () => {
+  test('renders BlueOne logo image', async () => {
+    await renderAndWait();
+    expect(screen.getByAltText('BlueOne')).toBeInTheDocument();
+  });
+
+  test('renders Holiday Preparation title', async () => {
+    await renderAndWait();
+    expect(screen.getByText('Holiday Preparation')).toBeInTheDocument();
+  });
+
+  test('shows welcome message with client name', async () => {
+    await renderAndWait();
+    expect(screen.getByText(/welcome, smith family/i)).toBeInTheDocument();
+  });
+
+  test('renders History button', async () => {
+    await renderAndWait();
+    expect(screen.getByRole('button', { name: /history/i })).toBeInTheDocument();
+  });
+
+  test('renders Summary link', async () => {
+    await renderAndWait();
+    expect(screen.getByRole('link', { name: /summary/i })).toBeInTheDocument();
+  });
+
+  test('Summary link points to correct path', async () => {
+    await renderAndWait();
+    const link = screen.getByRole('link', { name: /summary/i });
+    expect(link).toHaveAttribute('href', `/client-space/${mockToken}/summary`);
+  });
+});
+
+describe('ClientSpaceClient — Step Indicator', () => {
+  test('renders all 7 step labels on md+ screens', async () => {
+    await renderAndWait();
+    const steps = ['Your Charter', 'Crew Details', 'Travel & Logistics', 'Activities & Health', 'Food Preferences', 'Beverages & Bar', 'Special Requests'];
+    for (const label of steps) {
+      expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+    }
+  });
+
+  test('starts on step 0 (Your Charter)', async () => {
+    await renderAndWait();
+    // "Let's Get Started" button is only visible on step 0
+    expect(screen.getByRole('button', { name: /let's get started/i })).toBeInTheDocument();
+  });
+
+  test('resumes from lastSavedStep when prep has progress', async () => {
+    mockGetClientPreparation.mockResolvedValue({ ...mockPrep, lastSavedStep: 3 });
+    await renderAndWait();
+    // Step 3 shows Activities section title
+    await waitFor(() => expect(screen.getByText('Group Style')).toBeInTheDocument());
+  });
+});
+
+describe('ClientSpaceClient — Step 0: Charter Overview', () => {
+  test('displays charter start and end dates', async () => {
+    await renderAndWait();
+    expect(screen.getByText('Start')).toBeInTheDocument();
+    expect(screen.getByText('End')).toBeInTheDocument();
+  });
+
+  test('displays vessel name', async () => {
+    await renderAndWait();
+    expect(screen.getByText('Fountaine Pajot Aura 51')).toBeInTheDocument();
+  });
+
+  test('displays guest count', async () => {
+    await renderAndWait();
+    expect(screen.getByText('4 pax')).toBeInTheDocument();
+  });
+
+  test('displays embarkation marina', async () => {
+    await renderAndWait();
+    expect(screen.getAllByText('Alimos Marina').length).toBeGreaterThan(0);
+  });
+
+  test('advances to Crew Details on "Let\'s Get Started"', async () => {
+    await renderAndWait();
+    fireEvent.click(screen.getByRole('button', { name: /let's get started/i }));
+    await waitFor(() => expect(screen.getByText('Save Crew Details')).toBeInTheDocument());
+  });
+});
+
+describe('ClientSpaceClient — Step 1: Crew Details', () => {
+  beforeEach(async () => {
+    await renderAndWait();
+    fireEvent.click(screen.getByRole('button', { name: /let's get started/i }));
+    await waitFor(() => expect(screen.getByText('Save Crew Details')).toBeInTheDocument());
+  });
+
+  test('renders one crew card per passenger', () => {
+    // 4 passengers → 4 "Passenger N" labels
+    expect(screen.getByText('Passenger 1')).toBeInTheDocument();
+    expect(screen.getByText('Passenger 4')).toBeInTheDocument();
+  });
+
+  test('first crew card is expanded by default showing name fields', async () => {
+    // expanded state starts at 0 so Passenger 1 is open immediately
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('First name')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Last name')).toBeInTheDocument();
+    });
+  });
+
+  test('first crew card is expanded by default showing dietary and medical fields', async () => {
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/vegetarian/i)).toBeInTheDocument();
+      expect(screen.getByPlaceholderText(/conditions the crew/i)).toBeInTheDocument();
+    });
+  });
+
+  test('clicking a collapsed card switches the open card', async () => {
+    // Passenger 2 (index 1) starts collapsed — clicking it opens it and closes Passenger 1
+    const btn = screen.getAllByRole('button', { name: /passenger 2/i })[0];
+    fireEvent.click(btn);
+    await waitFor(() => {
+      // Only one card open at a time — still one "First name" placeholder (now Pax 2's)
+      expect(screen.getAllByPlaceholderText('First name').length).toBe(1);
+    });
+  });
+
+  test('Save Crew Details calls saveCrew and saveStep', async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save Crew Details' }));
+    await waitFor(() => expect(mockSaveCrew).toHaveBeenCalledWith(mockToken, expect.any(Array)));
+    expect(mockSaveStep).toHaveBeenCalled();
+  });
+
+  test('Save Crew Details creates a snapshot', async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save Crew Details' }));
+    await waitFor(() => expect(mockSaveSnapshot).toHaveBeenCalledWith(mockToken, expect.anything(), 'Crew details'));
+  });
+});
+
+describe('ClientSpaceClient — Step 2: Travel & Logistics', () => {
+  beforeEach(async () => {
+    mockGetClientPreparation.mockResolvedValue({ ...mockPrep, lastSavedStep: 2 });
+    await renderAndWait();
+    await waitFor(() => expect(screen.getByText('Save Travel Details')).toBeInTheDocument());
+  });
+
+  test('renders Group 1 by default', () => {
+    expect(screen.getByText('Group 1')).toBeInTheDocument();
+  });
+
+  test('shows all passengers in default group', () => {
+    expect(screen.getByText('All passengers')).toBeInTheDocument();
+  });
+
+  test('Add Travel Group button creates a second column', async () => {
+    fireEvent.click(screen.getByRole('button', { name: /add travel group/i }));
+    await waitFor(() => expect(screen.getByText('Group 2')).toBeInTheDocument());
+  });
+
+  test('renders Arrival and Departure section labels', () => {
+    expect(screen.getByText('Arrival')).toBeInTheDocument();
+    expect(screen.getByText('Departure')).toBeInTheDocument();
+  });
+
+  test('Save Travel Details calls saveTravel', async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save Travel Details' }));
+    await waitFor(() => expect(mockSaveTravel).toHaveBeenCalledWith(mockToken, expect.objectContaining({ groups: expect.any(Array) })));
+  });
+
+  test('Save Travel Details creates a snapshot', async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save Travel Details' }));
+    await waitFor(() => expect(mockSaveSnapshot).toHaveBeenCalledWith(mockToken, expect.anything(), 'Travel & logistics'));
+  });
+});
+
+describe('ClientSpaceClient — Step 3: Activities & Health', () => {
+  beforeEach(async () => {
+    mockGetClientPreparation.mockResolvedValue({ ...mockPrep, lastSavedStep: 3 });
+    await renderAndWait();
+    await waitFor(() => expect(screen.getByText('Save Activities & Health')).toBeInTheDocument());
+  });
+
+  test('renders Group Style section', () => {
+    expect(screen.getByText('Group Style')).toBeInTheDocument();
+  });
+
+  test('renders group style pill options', () => {
+    expect(screen.getByRole('button', { name: /active & on the go/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /relaxed & laid-back/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /a bit of both/i })).toBeInTheDocument();
+  });
+
+  test('renders Activities section with chips', () => {
+    expect(screen.getByText('Activities')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sailing' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Swimming' })).toBeInTheDocument();
+  });
+
+  test('clicking an activity chip toggles selection', async () => {
+    const chip = screen.getByRole('button', { name: 'Sailing' });
+    fireEvent.click(chip);
+    await waitFor(() => expect(chip).toHaveClass('bg-blue-600'));
+  });
+
+  test('renders Health & Experience section with textareas', () => {
+    expect(screen.getByText('Health & Experience')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/heart conditions/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/sailing background/i)).toBeInTheDocument();
+  });
+
+  test('Save Activities & Health calls saveActivities', async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save Activities & Health' }));
+    await waitFor(() => expect(mockSaveActivities).toHaveBeenCalledWith(mockToken, expect.any(Object)));
+  });
+
+  test('Save creates snapshot with correct label', async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save Activities & Health' }));
+    await waitFor(() => expect(mockSaveSnapshot).toHaveBeenCalledWith(mockToken, expect.anything(), 'Activities & health'));
+  });
+});
+
+describe('ClientSpaceClient — Step 4: Food Preferences', () => {
+  beforeEach(async () => {
+    mockGetClientPreparation.mockResolvedValue({ ...mockPrep, lastSavedStep: 4 });
+    await renderAndWait();
+    await waitFor(() => expect(screen.getByText('Save Food Preferences')).toBeInTheDocument());
+  });
+
+  test('renders Food Preferences by Category section', () => {
+    expect(screen.getByText('Food Preferences by Category')).toBeInTheDocument();
+  });
+
+  test('renders all 6 food category labels', () => {
+    for (const cat of ['Seafood', 'Meat', 'Fruit', 'Vegetables', 'Dairy', 'Other']) {
+      expect(screen.getAllByText(cat).length).toBeGreaterThan(0);
+    }
+  });
+
+  test('each category has Likes, Dislikes, Allergies fields', () => {
+    const likesFields = screen.getAllByPlaceholderText(/grilled fish/i);
+    expect(likesFields.length).toBeGreaterThan(0);
+    const dislikeFields = screen.getAllByPlaceholderText(/anchovies/i);
+    expect(dislikeFields.length).toBeGreaterThan(0);
+    const allergyFields = screen.getAllByPlaceholderText(/shellfish/i);
+    expect(allergyFields.length).toBeGreaterThan(0);
+  });
+
+  test('renders Breakfast section with style chips', () => {
+    expect(screen.getByText('Breakfast')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /light \/ cold/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /american/i })).toBeInTheDocument();
+  });
+
+  test('renders Lunch and Dinner sections', () => {
+    expect(screen.getByText('Lunch')).toBeInTheDocument();
+    expect(screen.getByText('Dinner')).toBeInTheDocument();
+  });
+
+  test('Save Food Preferences calls saveFood', async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save Food Preferences' }));
+    await waitFor(() => expect(mockSaveFood).toHaveBeenCalledWith(mockToken, expect.any(Object)));
+  });
+
+  test('Save creates snapshot with correct label', async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save Food Preferences' }));
+    await waitFor(() => expect(mockSaveSnapshot).toHaveBeenCalledWith(mockToken, expect.anything(), 'Food preferences'));
+  });
+});
+
+describe('ClientSpaceClient — Step 4: Per-passenger notes on food categories', () => {
+  beforeEach(async () => {
+    mockGetClientPreparation.mockResolvedValue({
+      ...mockPrep,
+      lastSavedStep: 4,
+      crew: [
+        { firstName: 'Alice', lastName: 'Smith', gender: '', dateOfBirth: '', nationality: '', passportNumber: '', dietaryRestrictions: '', medicalNotes: '' },
+        { firstName: 'Bob', lastName: 'Smith', gender: '', dateOfBirth: '', nationality: '', passportNumber: '', dietaryRestrictions: '', medicalNotes: '' },
+      ],
+    });
+    await renderAndWait();
+    await waitFor(() => expect(screen.getByText('Save Food Preferences')).toBeInTheDocument());
+  });
+
+  test('shows "Per passenger details" toggle on each food category', () => {
+    const toggles = screen.getAllByText(/per passenger details/i);
+    expect(toggles.length).toBeGreaterThanOrEqual(6); // one per category
+  });
+
+  test('expanding per-passenger toggle reveals passenger name inputs', async () => {
+    const toggles = screen.getAllByText(/per passenger details/i);
+    fireEvent.click(toggles[0]);
+    await waitFor(() => {
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+      expect(screen.getByText('Bob Smith')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('ClientSpaceClient — Step 5: Beverages & Bar', () => {
+  beforeEach(async () => {
+    mockGetClientPreparation.mockResolvedValue({ ...mockPrep, lastSavedStep: 5 });
+    await renderAndWait();
+    await waitFor(() => expect(screen.getByText('Save Beverage Preferences')).toBeInTheDocument());
+  });
+
+  test('renders Hot Beverages section', () => {
+    expect(screen.getByText('Hot Beverages')).toBeInTheDocument();
+  });
+
+  test('renders beverage chip options', () => {
+    expect(screen.getByRole('button', { name: 'Espresso' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cappuccino' })).toBeInTheDocument();
+  });
+
+  test('renders Sodas, Juices & Water table section', () => {
+    expect(screen.getByText('Sodas, Juices & Water')).toBeInTheDocument();
+    expect(screen.getByText('Coke 0.5 l')).toBeInTheDocument();
+  });
+
+  test('renders Wines & Sparkling table section', () => {
+    expect(screen.getByText('Wines & Sparkling')).toBeInTheDocument();
+    expect(screen.getByText('White Wine')).toBeInTheDocument();
+    expect(screen.getByText('Rosé Wine')).toBeInTheDocument();
+  });
+
+  test('renders Spirits & Beer table section', () => {
+    expect(screen.getByText('Spirits & Beer')).toBeInTheDocument();
+    expect(screen.getByText('Vodka')).toBeInTheDocument();
+    expect(screen.getByText('Gin')).toBeInTheDocument();
+  });
+
+  test('renders Qty and Brand columns', () => {
+    const qtyLabels = screen.getAllByText('Qty');
+    expect(qtyLabels.length).toBeGreaterThan(0);
+    const brandLabels = screen.getAllByText('Brand / Notes');
+    expect(brandLabels.length).toBeGreaterThan(0);
+  });
+
+  test('Save Beverage Preferences calls saveBeverages', async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save Beverage Preferences' }));
+    await waitFor(() => expect(mockSaveBeverages).toHaveBeenCalledWith(mockToken, expect.any(Object)));
+  });
+
+  test('Save creates snapshot with correct label', async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save Beverage Preferences' }));
+    await waitFor(() => expect(mockSaveSnapshot).toHaveBeenCalledWith(mockToken, expect.anything(), 'Beverages & bar'));
+  });
+});
+
+describe('ClientSpaceClient — Step 6: Special Requests & Checklist', () => {
+  beforeEach(async () => {
+    mockGetClientPreparation.mockResolvedValue({ ...mockPrep, lastSavedStep: 6 });
+    await renderAndWait();
+    await waitFor(() => expect(screen.getByText('Save & Complete')).toBeInTheDocument());
+  });
+
+  test('renders Special Requests section', () => {
+    expect(screen.getAllByText('Special Requests').length).toBeGreaterThan(0);
+  });
+
+  test('renders special occasion field', () => {
+    expect(screen.getByPlaceholderText(/birthday, anniversary/i)).toBeInTheDocument();
+  });
+
+  test('renders music atmosphere field', () => {
+    expect(screen.getByPlaceholderText(/jazz, mediterranean/i)).toBeInTheDocument();
+  });
+
+  test('renders emergency contact fields', () => {
+    expect(screen.getByPlaceholderText('Full name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Phone number')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Relationship')).toBeInTheDocument();
+  });
+
+  test('renders Pre-Departure Checklist heading', () => {
+    expect(screen.getByText('Pre-Departure Checklist')).toBeInTheDocument();
+  });
+
+  test('renders checklist categories from mock', () => {
+    expect(screen.getByText('Documents')).toBeInTheDocument();
+    expect(screen.getByText('Clothing & Packing')).toBeInTheDocument();
+  });
+
+  test('renders checklist items', () => {
+    expect(screen.getByText('Passport valid for 6+ months')).toBeInTheDocument();
+    expect(screen.getByText('Travel insurance arranged')).toBeInTheDocument();
+  });
+
+  test('shows 0 / 3 progress initially', () => {
+    expect(screen.getByText('0 / 3')).toBeInTheDocument();
+  });
+
+  test('toggling a checklist item calls saveChecklist', async () => {
+    const item = screen.getByRole('button', { name: /passport valid/i });
+    fireEvent.click(item);
+    await waitFor(() => expect(mockSaveChecklist).toHaveBeenCalledWith(
+      mockToken,
+      expect.objectContaining({ 'doc-passport': true })
+    ));
+  });
+
+  test('toggling a checklist item updates progress counter', async () => {
+    const item = screen.getByRole('button', { name: /passport valid/i });
+    fireEvent.click(item);
+    await waitFor(() => expect(screen.getByText('1 / 3')).toBeInTheDocument());
+  });
+
+  test('Save & Complete calls saveSpecial and saveStep(6)', async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save & Complete' }));
+    await waitFor(() => expect(mockSaveSpecial).toHaveBeenCalledWith(mockToken, expect.any(Object)));
+    expect(mockSaveStep).toHaveBeenCalledWith(mockToken, 6);
+  });
+
+  test('Save creates snapshot with correct label', async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Save & Complete' }));
+    await waitFor(() => expect(mockSaveSnapshot).toHaveBeenCalledWith(mockToken, expect.anything(), 'Special requests'));
+  });
+});
+
+describe('ClientSpaceClient — History drawer', () => {
+  test('clicking History button loads and shows history drawer', async () => {
+    mockGetHistory.mockResolvedValue([
+      {
+        id: 'snap-1',
+        label: 'Crew details',
+        savedAt: { toDate: () => new Date('2026-06-01T10:00:00') },
+        data: mockPrep,
+      },
+    ]);
+    await renderAndWait();
+    fireEvent.click(screen.getByRole('button', { name: /history/i }));
+    await waitFor(() => expect(screen.getByText('Crew details')).toBeInTheDocument());
+  });
+
+  test('History drawer shows empty state when no snapshots', async () => {
+    mockGetHistory.mockResolvedValue([]);
+    await renderAndWait();
+    fireEvent.click(screen.getByRole('button', { name: /history/i }));
+    await waitFor(() => expect(screen.getByText(/no history yet/i)).toBeInTheDocument());
+  });
+});

--- a/__tests__/client-space.test.tsx
+++ b/__tests__/client-space.test.tsx
@@ -326,21 +326,22 @@ describe('ClientSpaceClient — Step 2: Travel & Logistics', () => {
   });
 
   test('renders Group 1 by default', () => {
-    expect(screen.getByText('Group 1')).toBeInTheDocument();
+    // Both mobile card and desktop table render Group 1 in the DOM
+    expect(screen.getAllByText('Group 1').length).toBeGreaterThan(0);
   });
 
   test('shows all passengers in default group', () => {
-    expect(screen.getByText('All passengers')).toBeInTheDocument();
+    expect(screen.getAllByText('All passengers').length).toBeGreaterThan(0);
   });
 
   test('Add Travel Group button creates a second column', async () => {
     fireEvent.click(screen.getByRole('button', { name: /add travel group/i }));
-    await waitFor(() => expect(screen.getByText('Group 2')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByText('Group 2').length).toBeGreaterThan(0));
   });
 
   test('renders Arrival and Departure section labels', () => {
-    expect(screen.getByText('Arrival')).toBeInTheDocument();
-    expect(screen.getByText('Departure')).toBeInTheDocument();
+    expect(screen.getAllByText('Arrival').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Departure').length).toBeGreaterThan(0);
   });
 
   test('Save Travel Details calls saveTravel', async () => {

--- a/app/admin/AdminDashboardClient.tsx
+++ b/app/admin/AdminDashboardClient.tsx
@@ -22,6 +22,7 @@ import type { Review } from '../../lib/reviews';
 import StarRating from '../components/StarRating';
 import MarinaMap from './MarinaMap';
 import { marinasByRegion, getMarinaById, DEFAULT_MARINA_ID } from '../marinas-data';
+import { initClientSpace } from '../../lib/clientSpace';
 
 type Tab = 'charters' | 'contacts' | 'reviews';
 type SortDir = 'asc' | 'desc';
@@ -77,6 +78,8 @@ export default function AdminDashboardClient() {
   const [editRedelivery, setEditRedelivery] = useState(DEFAULT_MARINA_ID);
   const [savingLocations, setSavingLocations] = useState(false);
   const [savingStatus, setSavingStatus] = useState(false);
+  const [generatingClientSpace, setGeneratingClientSpace] = useState<string | null>(null);
+  const [copiedClientSpace, setCopiedClientSpace] = useState<string | null>(null);
 
   useEffect(() => {
     setLoading(true);
@@ -196,6 +199,24 @@ export default function AdminDashboardClient() {
     setReviews(prev => {
       const updated = prev.map(r => r.id === id ? { ...r, order: newOrder } : r);
       return [...updated].sort((a, b) => (b.order ?? 0) - (a.order ?? 0));
+    });
+  }
+
+  async function handleGenerateClientSpace(charterId: string) {
+    setGeneratingClientSpace(charterId);
+    try {
+      const token = await initClientSpace(charterId);
+      setCharters(prev => prev.map(c => c.id === charterId ? { ...c, clientSpaceToken: token } : c));
+    } finally {
+      setGeneratingClientSpace(null);
+    }
+  }
+
+  function copyClientSpaceLink(token: string) {
+    const url = `${window.location.origin}/client-space/${token}`;
+    navigator.clipboard.writeText(url).then(() => {
+      setCopiedClientSpace(token);
+      setTimeout(() => setCopiedClientSpace(null), 2000);
     });
   }
 
@@ -418,6 +439,36 @@ export default function AdminDashboardClient() {
                     >
                       + Create Proposal
                     </a>
+                  )}
+                </div>
+
+                {/* Client Preparation Space */}
+                <div className="flex flex-wrap items-center gap-2">
+                  {currentCharter.clientSpaceToken ? (
+                    <>
+                      <a
+                        href={`/client-space/${currentCharter.clientSpaceToken}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium bg-teal-500/20 text-teal-200 hover:bg-teal-500/30 transition-colors"
+                      >
+                        🧭 Client Space
+                      </a>
+                      <button
+                        onClick={() => copyClientSpaceLink(currentCharter.clientSpaceToken!)}
+                        className="text-xs text-blue-400 hover:text-white transition-colors"
+                      >
+                        {copiedClientSpace === currentCharter.clientSpaceToken ? '✓ Copied' : 'Copy link'}
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      onClick={() => handleGenerateClientSpace(currentCharter.id)}
+                      disabled={generatingClientSpace === currentCharter.id}
+                      className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-medium bg-white/10 hover:bg-white/20 text-blue-300 hover:text-white transition-colors disabled:opacity-50"
+                    >
+                      {generatingClientSpace === currentCharter.id ? '…' : '+ Client Space'}
+                    </button>
                   )}
                 </div>
 

--- a/app/client-space/[token]/ClientSpaceClient.tsx
+++ b/app/client-space/[token]/ClientSpaceClient.tsx
@@ -162,7 +162,7 @@ function Toast({ msg, onDone }: { msg: string; onDone: () => void }) {
 // Reusable field components
 // ---------------------------------------------------------------------------
 
-const inputBase = 'w-full rounded-lg border border-blue-200 bg-white px-2.5 py-1.5 text-xs text-blue-900 placeholder:text-blue-300 transition-all focus:outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200/60 shadow-sm hover:border-blue-300';
+const inputBase = 'w-full bg-transparent border-0 border-b border-blue-300/60 rounded-none px-0 py-1.5 text-xs text-blue-900 placeholder:text-blue-300/70 transition-all focus:outline-none focus:border-blue-600 focus:ring-0';
 
 function FieldLabel({ children }: { children: ReactNode }) {
   return <label className="block text-[10px] font-semibold text-blue-600 uppercase tracking-wide mb-1">{children}</label>;
@@ -300,7 +300,7 @@ function PassengerNotes({ crew, notes, onChange }: {
                   value={notes[String(i)] ?? ''}
                   onChange={e => onChange({ ...notes, [String(i)]: e.target.value })}
                   placeholder="Specific note…"
-                  className="flex-1 rounded-lg border border-blue-200 bg-white/80 px-2.5 py-1.5 text-xs text-blue-900 placeholder:text-blue-300 focus:outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200/60 transition-all"
+                  className="flex-1 bg-transparent border-0 border-b border-blue-300/60 rounded-none px-0 py-1.5 text-xs text-blue-900 placeholder:text-blue-300/70 focus:outline-none focus:border-blue-600 transition-all"
                 />
               </div>
             );

--- a/app/client-space/[token]/ClientSpaceClient.tsx
+++ b/app/client-space/[token]/ClientSpaceClient.tsx
@@ -1089,6 +1089,16 @@ export default function ClientSpaceClient({ token }: Props) {
               <p className="text-white text-sm font-semibold leading-tight">Holiday Preparation</p>
               {charter.name && <p className="text-blue-300 text-xs truncate">Welcome, {charter.name}</p>}
             </div>
+            <a
+              href={`/client-space/${token}/summary`}
+              className="flex-shrink-0 px-3 py-1.5 rounded-xl text-xs font-semibold bg-white/15 hover:bg-white/25 text-white border border-white/20 transition-colors flex items-center gap-1.5"
+              title="View full summary"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              Summary
+            </a>
           </div>
           <StepIndicator current={currentStep} />
         </div>
@@ -1198,6 +1208,15 @@ export default function ClientSpaceClient({ token }: Props) {
             <p className="text-3xl mb-2">⛵</p>
             <h3 className="text-white text-lg font-bold mb-1">All Set!</h3>
             <p className="text-emerald-200 text-sm">Your preparation is complete. The BlueOne team has everything they need to plan your perfect holiday.</p>
+            <a
+              href={`/client-space/${token}/summary`}
+              className="inline-flex items-center gap-2 mt-4 px-6 py-2.5 rounded-xl text-sm font-semibold bg-white text-blue-800 hover:bg-blue-50 transition-colors shadow-sm"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              View & Print Summary
+            </a>
             <p className="text-emerald-300 text-xs mt-3">Questions? Contact us at <a href={`mailto:${CONTACT.email}`} className="underline">{CONTACT.email}</a></p>
           </div>
         )}

--- a/app/client-space/[token]/ClientSpaceClient.tsx
+++ b/app/client-space/[token]/ClientSpaceClient.tsx
@@ -780,14 +780,6 @@ function BeveragesStep({ initial, onSave }: {
   const [data, setData] = useState<BeveragePreferences>(initial);
   const [saving, setSaving] = useState(false);
 
-  function toggleWarm(item: string) {
-    const current = data.warmBeverages ?? [];
-    setData(prev => ({
-      ...prev,
-      warmBeverages: current.includes(item) ? current.filter(x => x !== item) : [...current, item],
-    }));
-  }
-
   function updateRow(group: 'sodas' | 'wines' | 'spirits', key: string, val: { preferredBrand?: string; qty?: number; remarks?: string }) {
     setData(prev => ({ ...prev, [group]: { ...(prev[group] ?? {}), [key]: val } }));
   }

--- a/app/client-space/[token]/ClientSpaceClient.tsx
+++ b/app/client-space/[token]/ClientSpaceClient.tsx
@@ -162,10 +162,10 @@ function Toast({ msg, onDone }: { msg: string; onDone: () => void }) {
 // Reusable field components
 // ---------------------------------------------------------------------------
 
-const inputBase = 'w-full rounded-xl border border-blue-200 bg-white px-3 py-2 text-sm text-blue-900 placeholder:text-blue-300 transition-all focus:outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-200/60 shadow-sm hover:border-blue-300';
+const inputBase = 'w-full rounded-lg border border-blue-200 bg-white px-2.5 py-1.5 text-xs text-blue-900 placeholder:text-blue-300 transition-all focus:outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200/60 shadow-sm hover:border-blue-300';
 
 function FieldLabel({ children }: { children: ReactNode }) {
-  return <label className="block text-xs font-semibold text-blue-700 uppercase tracking-wide mb-1.5">{children}</label>;
+  return <label className="block text-[10px] font-semibold text-blue-600 uppercase tracking-wide mb-1">{children}</label>;
 }
 
 function TextInput({ value, onChange, placeholder, type = 'text' }: {
@@ -217,15 +217,15 @@ function PillToggle({ options, value, onChange }: {
   onChange: (v: string) => void;
 }) {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap gap-1.5">
       {options.map(o => (
         <button
           key={o.id}
           type="button"
           onClick={() => onChange(value === o.id ? '' : o.id)}
-          className={`px-4 py-2 rounded-xl text-xs font-semibold transition-all border shadow-sm ${
+          className={`px-2.5 py-1 rounded-lg text-xs font-semibold transition-all border ${
             value === o.id
-              ? 'bg-blue-600 border-blue-600 text-white shadow-blue-200'
+              ? 'bg-blue-600 border-blue-600 text-white'
               : 'bg-white border-blue-200 text-blue-700 hover:border-blue-400 hover:bg-blue-50'
           }`}
         >
@@ -245,13 +245,13 @@ function MultiChip({ options, values, onChange }: {
     onChange(values.includes(opt) ? values.filter(v => v !== opt) : [...values, opt]);
   }
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap gap-1.5">
       {options.map(o => (
         <button
           key={o}
           type="button"
           onClick={() => toggle(o)}
-          className={`px-3 py-1.5 rounded-xl text-xs font-semibold transition-all border shadow-sm ${
+          className={`px-2.5 py-1 rounded-lg text-xs font-semibold transition-all border ${
             values.includes(o)
               ? 'bg-blue-600 border-blue-600 text-white'
               : 'bg-white border-blue-200 text-blue-600 hover:border-blue-400 hover:bg-blue-50'
@@ -322,9 +322,9 @@ function AutoSaveIndicator({ status }: { status: 'idle' | 'saving' | 'saved' }) 
 
 function SectionCard({ title, autoSave, children }: { title: string; autoSave?: 'idle' | 'saving' | 'saved'; children: ReactNode }) {
   return (
-    <div className="bg-white/80 backdrop-blur-sm border border-blue-100 rounded-2xl p-4 space-y-4 shadow-sm">
+    <div className="bg-white/80 backdrop-blur-sm border border-blue-100 rounded-xl p-3 space-y-3 shadow-sm">
       <div className="flex items-center justify-between">
-        <h3 className="text-sm font-bold text-blue-900 tracking-tight">{title}</h3>
+        <h3 className="text-xs font-bold text-blue-900 uppercase tracking-wide">{title}</h3>
         {autoSave && <AutoSaveIndicator status={autoSave} />}
       </div>
       {children}
@@ -450,7 +450,7 @@ function CrewStep({ count, initial, onSave, onAutoSave }: {
           <button
             type="button"
             onClick={() => setExpanded(expanded === i ? -1 : i)}
-            className="w-full flex items-center justify-between px-4 py-3 text-left"
+            className="w-full flex items-center justify-between px-3 py-2 text-left"
           >
             <div>
               <span className="text-[10px] font-bold text-blue-400 uppercase tracking-wide">Passenger {i + 1}</span>
@@ -464,8 +464,8 @@ function CrewStep({ count, initial, onSave, onAutoSave }: {
           </button>
 
           {expanded === i && (
-            <div className="px-4 pb-4 space-y-3 border-t border-blue-100">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-3">
+            <div className="px-3 pb-3 space-y-2 border-t border-blue-100">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 pt-2">
                 <div>
                   <FieldLabel>First Name</FieldLabel>
                   <TextInput value={m.firstName} onChange={v => update(i, 'firstName', v)} placeholder="First name" />
@@ -536,7 +536,7 @@ function initGroups(initial: TravelLogistics, passengerCount: number): TravelGro
 function TableRow({ label, children }: { label: string; children: ReactNode }) {
   return (
     <tr className="border-t border-blue-100">
-      <td className="py-3 pr-4 text-xs font-semibold text-blue-500 uppercase tracking-wide whitespace-nowrap w-36 align-top pt-3.5">
+      <td className="py-2 pr-3 text-[10px] font-semibold text-blue-500 uppercase tracking-wide whitespace-nowrap w-32 align-top pt-2.5">
         {label}
       </td>
       {children}
@@ -620,13 +620,13 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
         </button>
       </div>
 
-      <div className="bg-white/80 backdrop-blur-sm border border-blue-100 rounded-2xl shadow-sm overflow-x-auto">
+      <div className="bg-white/80 backdrop-blur-sm border border-blue-100 rounded-xl shadow-sm overflow-x-auto">
         <table className="w-full min-w-[480px]">
           <thead>
             <tr className="border-b border-blue-100">
               <th className="py-3 pr-4 w-36" />
               {groups.map((g, gi) => (
-                <th key={g.id} className="py-3 px-3 text-left">
+                <th key={g.id} className="py-2 px-2 text-left">
                   <div className="flex items-center justify-between gap-2">
                     <span className="text-sm font-bold text-blue-900">Group {gi + 1}</span>
                     {colCount > 1 && (
@@ -654,7 +654,7 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
             {/* Members row */}
             <TableRow label="Members">
               {groups.map(g => (
-                <td key={g.id} className="py-3 px-3 align-top">
+                <td key={g.id} className="py-1.5 px-2 align-top">
                   <div className="flex flex-wrap gap-1.5">
                     {Array.from({ length: passengerCount }, (_, idx) => {
                       const selected = g.memberIndices.includes(idx);
@@ -687,7 +687,7 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
 
             <TableRow label="Date">
               {groups.map(g => (
-                <td key={g.id} className="py-2 px-3 align-top">
+                <td key={g.id} className="py-1.5 px-2 align-top">
                   <TextInput value={g.arrivalDate ?? ''} onChange={v => updateGroup(g.id, { arrivalDate: v })} type="date" />
                 </td>
               ))}
@@ -695,7 +695,7 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
 
             <TableRow label="Time">
               {groups.map(g => (
-                <td key={g.id} className="py-2 px-3 align-top">
+                <td key={g.id} className="py-1.5 px-2 align-top">
                   <TextInput value={g.arrivalTime ?? ''} onChange={v => updateGroup(g.id, { arrivalTime: v })} type="time" />
                 </td>
               ))}
@@ -703,7 +703,7 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
 
             <TableRow label="Flight No.">
               {groups.map(g => (
-                <td key={g.id} className="py-2 px-3 align-top">
+                <td key={g.id} className="py-1.5 px-2 align-top">
                   <TextInput value={g.arrivalFlight ?? ''} onChange={v => updateGroup(g.id, { arrivalFlight: v })} placeholder="e.g. EZY1234" />
                 </td>
               ))}
@@ -726,7 +726,7 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
 
             <TableRow label="Transfer to marina?">
               {groups.map(g => (
-                <td key={g.id} className="py-2 px-3 align-top">
+                <td key={g.id} className="py-1.5 px-2 align-top">
                   <PillToggle
                     options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
                     value={g.transferFromAirport ? 'yes' : g.transferFromAirport === false ? 'no' : ''}
@@ -745,7 +745,7 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
 
             <TableRow label="Date">
               {groups.map(g => (
-                <td key={g.id} className="py-2 px-3 align-top">
+                <td key={g.id} className="py-1.5 px-2 align-top">
                   <TextInput value={g.departureDate ?? ''} onChange={v => updateGroup(g.id, { departureDate: v })} type="date" />
                 </td>
               ))}
@@ -753,7 +753,7 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
 
             <TableRow label="Time">
               {groups.map(g => (
-                <td key={g.id} className="py-2 px-3 align-top">
+                <td key={g.id} className="py-1.5 px-2 align-top">
                   <TextInput value={g.departureTime ?? ''} onChange={v => updateGroup(g.id, { departureTime: v })} type="time" />
                 </td>
               ))}
@@ -761,7 +761,7 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
 
             <TableRow label="Flight No.">
               {groups.map(g => (
-                <td key={g.id} className="py-2 px-3 align-top">
+                <td key={g.id} className="py-1.5 px-2 align-top">
                   <TextInput value={g.departureFlight ?? ''} onChange={v => updateGroup(g.id, { departureFlight: v })} placeholder="e.g. BA456" />
                 </td>
               ))}
@@ -769,7 +769,7 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
 
             <TableRow label="Transfer to airport?">
               {groups.map(g => (
-                <td key={g.id} className="py-2 px-3 align-top">
+                <td key={g.id} className="py-1.5 px-2 align-top">
                   <PillToggle
                     options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
                     value={g.transferToAirport ? 'yes' : g.transferToAirport === false ? 'no' : ''}
@@ -914,9 +914,9 @@ function FoodStep({ initial, crew, onSave, onAutoSave }: {
             const key = cat.toLowerCase() as CatKey;
             const catData = (data[key as keyof FoodPreferences] as { likes?: string; dislikes?: string; allergies?: string }) ?? {};
             return (
-              <div key={cat} className="border border-blue-100 rounded-xl p-3 space-y-3 bg-white/50">
-                <p className="text-xs font-bold text-blue-800 uppercase tracking-wide">{cat}</p>
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              <div key={cat} className="border border-blue-100 rounded-lg p-2.5 space-y-2 bg-white/50">
+                <p className="text-[10px] font-bold text-blue-700 uppercase tracking-wide">{cat}</p>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-1.5">
                   <div>
                     <FieldLabel>Likes</FieldLabel>
                     <TextInput value={catData.likes ?? ''} onChange={v => setCategory(key, 'likes', v)} placeholder="e.g. grilled fish" />
@@ -1043,7 +1043,7 @@ function BeverageRow({ label, item, crew, onChange }: {
   crew: CrewMember[];
   onChange: (v: { preferredBrand?: string; qty?: number; remarks?: string; passengerNotes?: Record<string, string> }) => void;
 }) {
-  const inputCell = 'rounded-lg border border-blue-200 bg-white px-2.5 py-2 text-xs text-blue-900 placeholder:text-blue-300 focus:outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200/60 transition-all shadow-sm hover:border-blue-300 w-full';
+  const inputCell = 'rounded-lg border border-blue-200 bg-white px-2 py-1.5 text-xs text-blue-900 placeholder:text-blue-300 focus:outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200/60 transition-all shadow-sm hover:border-blue-300 w-full';
   return (
     <div className="py-2.5 border-b border-blue-50 last:border-0">
       <div className="grid grid-cols-[2fr_1fr_2fr] gap-2 items-center">

--- a/app/client-space/[token]/ClientSpaceClient.tsx
+++ b/app/client-space/[token]/ClientSpaceClient.tsx
@@ -162,7 +162,7 @@ function Toast({ msg, onDone }: { msg: string; onDone: () => void }) {
 // Reusable field components
 // ---------------------------------------------------------------------------
 
-const inputBase = 'w-full appearance-none bg-transparent border-0 border-b border-blue-300/60 rounded-none px-0 py-1.5 text-xs text-blue-900 placeholder:text-blue-300/70 transition-all focus:outline-none focus:border-blue-600 focus:ring-0';
+const inputBase = 'w-full appearance-none !bg-transparent !border-0 !border-b !border-blue-300/60 !rounded-none !px-0 !shadow-none py-1.5 text-xs text-blue-900 placeholder:text-blue-300/70 transition-all focus:outline-none focus:!border-blue-600 focus:!shadow-none';
 
 function FieldLabel({ children }: { children: ReactNode }) {
   return <label className="block text-[10px] font-semibold text-blue-600 uppercase tracking-wide mb-1">{children}</label>;
@@ -300,7 +300,7 @@ function PassengerNotes({ crew, notes, onChange }: {
                   value={notes[String(i)] ?? ''}
                   onChange={e => onChange({ ...notes, [String(i)]: e.target.value })}
                   placeholder="Specific note…"
-                  className="flex-1 bg-transparent border-0 border-b border-blue-300/60 rounded-none px-0 py-1.5 text-xs text-blue-900 placeholder:text-blue-300/70 focus:outline-none focus:border-blue-600 transition-all"
+                  className="flex-1 !bg-transparent !border-0 !border-b !border-blue-300/60 !rounded-none !px-0 !shadow-none py-1.5 text-xs text-blue-900 placeholder:text-blue-300/70 focus:outline-none focus:!border-blue-600 focus:!shadow-none transition-all"
                 />
               </div>
             );

--- a/app/client-space/[token]/ClientSpaceClient.tsx
+++ b/app/client-space/[token]/ClientSpaceClient.tsx
@@ -13,6 +13,9 @@ import {
   saveSpecial,
   saveChecklist,
   saveStep,
+  saveSnapshot,
+  getHistory,
+  restoreSnapshot,
   CHECKLIST_CATEGORIES,
   type ClientPreparation,
   type CrewMember,
@@ -21,6 +24,7 @@ import {
   type FoodPreferences,
   type BeveragePreferences,
   type SpecialRequests,
+  type PrepSnapshot,
 } from '../../../lib/clientSpace';
 import type { Charter } from '../../../lib/availability';
 import { getMarinaById } from '../../marinas-data';
@@ -35,6 +39,47 @@ const fmtDate = (iso: string) =>
 
 function nightCount(start: string, end: string) {
   return Math.round((new Date(end).getTime() - new Date(start).getTime()) / 86400000);
+}
+
+function fmtDateTime(ts: PrepSnapshot['savedAt'] | null | undefined): string {
+  if (!ts) return '—';
+  const d = ts.toDate?.() ?? new Date();
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) +
+    ' ' + d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
+}
+
+// Debounced auto-save hook. Skips the first render. Returns 'idle' | 'saving' | 'saved'.
+function useAutoSave<T>(
+  data: T,
+  saveFn: (data: T) => Promise<void>,
+  delay = 1800
+): 'idle' | 'saving' | 'saved' {
+  const [status, setStatus] = useState<'idle' | 'saving' | 'saved'>('idle');
+  const dataStr = JSON.stringify(data);
+  const prevStr = useRef(dataStr);
+  const saveFnRef = useRef(saveFn);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  saveFnRef.current = saveFn;
+
+  useEffect(() => {
+    if (dataStr === prevStr.current) return;
+    prevStr.current = dataStr;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setStatus('saving');
+    const snapshot = dataStr;
+    timerRef.current = setTimeout(async () => {
+      try {
+        await saveFnRef.current(JSON.parse(snapshot) as T);
+        setStatus('saved');
+        setTimeout(() => setStatus('idle'), 2500);
+      } catch {
+        setStatus('idle');
+      }
+    }, delay);
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, [dataStr, delay]);
+
+  return status;
 }
 
 const STEPS = [
@@ -117,7 +162,7 @@ function Toast({ msg, onDone }: { msg: string; onDone: () => void }) {
 // ---------------------------------------------------------------------------
 
 function FieldLabel({ children }: { children: ReactNode }) {
-  return <label className="block text-sm font-medium text-blue-900 mb-1">{children}</label>;
+  return <label className="block text-xs font-semibold text-blue-800 mb-1">{children}</label>;
 }
 
 function TextInput({ value, onChange, placeholder, type = 'text' }: {
@@ -129,7 +174,7 @@ function TextInput({ value, onChange, placeholder, type = 'text' }: {
       value={value}
       onChange={e => onChange(e.target.value)}
       placeholder={placeholder}
-      className="w-full border-2 border-blue-100 rounded-xl px-3 py-2 text-sm text-blue-900 focus:outline-none focus:border-blue-400 bg-white/80"
+      className="w-full border border-blue-200 rounded-lg px-2.5 py-1.5 text-xs text-blue-900 focus:outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200 bg-white/90"
     />
   );
 }
@@ -143,7 +188,7 @@ function TextArea({ value, onChange, placeholder, rows = 3 }: {
       onChange={e => onChange(e.target.value)}
       placeholder={placeholder}
       rows={rows}
-      className="w-full border-2 border-blue-100 rounded-xl px-3 py-2 text-sm text-blue-900 focus:outline-none focus:border-blue-400 bg-white/80 resize-none"
+      className="w-full border border-blue-200 rounded-lg px-2.5 py-1.5 text-xs text-blue-900 focus:outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200 bg-white/90 resize-none"
     />
   );
 }
@@ -155,7 +200,7 @@ function SelectInput({ value, onChange, options, placeholder }: {
     <select
       value={value}
       onChange={e => onChange(e.target.value)}
-      className="w-full border-2 border-blue-100 rounded-xl px-3 py-2 text-sm text-blue-900 focus:outline-none focus:border-blue-400 bg-white/80"
+      className="w-full border border-blue-200 rounded-lg px-2.5 py-1.5 text-xs text-blue-900 focus:outline-none focus:border-blue-400 bg-white/90"
     >
       {placeholder && <option value="">{placeholder}</option>}
       {options.map(o => <option key={o} value={o}>{o}</option>)}
@@ -169,13 +214,13 @@ function PillToggle({ options, value, onChange }: {
   onChange: (v: string) => void;
 }) {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap gap-1.5">
       {options.map(o => (
         <button
           key={o.id}
           type="button"
           onClick={() => onChange(value === o.id ? '' : o.id)}
-          className={`px-4 py-2 rounded-full text-sm font-medium transition-all border-2 ${
+          className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all border ${
             value === o.id
               ? 'bg-blue-600 border-blue-600 text-white'
               : 'bg-white border-blue-200 text-blue-700 hover:border-blue-400'
@@ -197,13 +242,13 @@ function MultiChip({ options, values, onChange }: {
     onChange(values.includes(opt) ? values.filter(v => v !== opt) : [...values, opt]);
   }
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap gap-1.5">
       {options.map(o => (
         <button
           key={o}
           type="button"
           onClick={() => toggle(o)}
-          className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all border-2 ${
+          className={`px-2.5 py-1 rounded-full text-xs font-medium transition-all border ${
             values.includes(o)
               ? 'bg-blue-600 border-blue-600 text-white'
               : 'bg-white border-blue-200 text-blue-600 hover:border-blue-400'
@@ -216,10 +261,22 @@ function MultiChip({ options, values, onChange }: {
   );
 }
 
-function SectionCard({ title, children }: { title: string; children: ReactNode }) {
+function AutoSaveIndicator({ status }: { status: 'idle' | 'saving' | 'saved' }) {
+  if (status === 'idle') return null;
   return (
-    <div className="bg-white/70 backdrop-blur-sm border border-blue-100 rounded-2xl p-5 space-y-4">
-      <h3 className="text-base font-bold text-blue-900">{title}</h3>
+    <span className={`text-[10px] font-medium transition-all ${status === 'saved' ? 'text-emerald-400' : 'text-blue-300 animate-pulse'}`}>
+      {status === 'saving' ? '⟳ saving…' : '✓ saved'}
+    </span>
+  );
+}
+
+function SectionCard({ title, autoSave, children }: { title: string; autoSave?: 'idle' | 'saving' | 'saved'; children: ReactNode }) {
+  return (
+    <div className="bg-white/70 backdrop-blur-sm border border-blue-100 rounded-xl p-3 space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-bold text-blue-900">{title}</h3>
+        {autoSave && <AutoSaveIndicator status={autoSave} />}
+      </div>
       {children}
     </div>
   );
@@ -233,7 +290,7 @@ function SaveButton({ onClick, saving, label = 'Save & Continue' }: {
       type="button"
       onClick={onClick}
       disabled={saving}
-      className="btn-primary px-8 py-3 text-sm font-semibold disabled:opacity-60 disabled:cursor-not-allowed"
+      className="btn-primary px-5 py-2 text-xs font-semibold disabled:opacity-60 disabled:cursor-not-allowed"
     >
       {saving ? 'Saving…' : label}
     </button>
@@ -246,26 +303,20 @@ function SaveButton({ onClick, saving, label = 'Save & Continue' }: {
 
 function StepIndicator({ current }: { current: number }) {
   return (
-    <div className="flex items-center gap-1 overflow-x-auto pb-1">
+    <div className="flex items-center gap-0.5 overflow-x-auto">
       {STEPS.map((label, i) => (
         <div key={i} className="flex items-center flex-shrink-0">
-          <div className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
-            i === current
-              ? 'bg-white text-blue-700 shadow-sm font-semibold'
-              : i < current
-              ? 'bg-white/30 text-white'
-              : 'bg-white/10 text-blue-200'
+          <div className={`flex items-center gap-1 px-2 py-1 rounded-full text-[11px] transition-all ${
+            i === current ? 'bg-white text-blue-700 font-semibold' : i < current ? 'bg-white/25 text-white' : 'bg-white/8 text-blue-300'
           }`}>
-            <span className={`w-4 h-4 rounded-full flex items-center justify-center text-[10px] font-bold flex-shrink-0 ${
-              i < current ? 'bg-emerald-400 text-white' : i === current ? 'bg-blue-600 text-white' : 'bg-white/20 text-blue-300'
+            <span className={`w-3.5 h-3.5 rounded-full flex items-center justify-center text-[9px] font-bold flex-shrink-0 ${
+              i < current ? 'bg-emerald-400 text-white' : i === current ? 'bg-blue-600 text-white' : 'bg-white/15 text-blue-400'
             }`}>
               {i < current ? '✓' : i + 1}
             </span>
-            <span className="hidden sm:inline">{label}</span>
+            <span className="hidden md:inline">{label}</span>
           </div>
-          {i < STEPS.length - 1 && (
-            <div className={`w-4 h-px mx-0.5 ${i < current ? 'bg-emerald-400/60' : 'bg-white/20'}`} />
-          )}
+          {i < STEPS.length - 1 && <div className={`w-3 h-px ${i < current ? 'bg-emerald-400/50' : 'bg-white/15'}`} />}
         </div>
       ))}
     </div>
@@ -282,27 +333,27 @@ function BookingOverview({ charter }: { charter: Charter }) {
   const nights = charter.startDate && charter.endDate ? nightCount(charter.startDate, charter.endDate) : null;
 
   return (
-    <div className="space-y-4">
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
         {[
-          { label: 'Charter Start', value: charter.startDate ? fmtDate(charter.startDate) : '—' },
-          { label: 'Charter End', value: charter.endDate ? `${fmtDate(charter.endDate)}${nights ? ` (${nights} nights)` : ''}` : '—' },
-          { label: 'Vessel', value: charter.boat ?? 'BlueOne — Fountaine Pajot Aura 51' },
-          { label: 'Guests', value: charter.passengers ? `${charter.passengers} passenger${charter.passengers > 1 ? 's' : ''}` : '—' },
+          { label: 'Start', value: charter.startDate ? fmtDate(charter.startDate) : '—' },
+          { label: 'End', value: charter.endDate ? `${fmtDate(charter.endDate)}${nights ? ` · ${nights}n` : ''}` : '—' },
+          { label: 'Vessel', value: charter.boat ?? 'Fountaine Pajot Aura 51' },
+          { label: 'Guests', value: charter.passengers ? `${charter.passengers} pax` : '—' },
           { label: 'Embarkation', value: delivery?.name ?? charter.embarkationPoint ?? '—' },
           { label: 'Disembarkation', value: redelivery?.name ?? delivery?.name ?? '—' },
-          ...(charter.selectedTheme ? [{ label: 'Experience Theme', value: charter.selectedTheme }] : []),
+          ...(charter.selectedTheme ? [{ label: 'Theme', value: charter.selectedTheme }] : []),
         ].map(({ label, value }) => (
-          <div key={label} className="bg-white/60 rounded-xl px-4 py-3">
-            <p className="text-xs font-semibold text-blue-400 uppercase tracking-wide mb-0.5">{label}</p>
-            <p className="text-sm font-medium text-blue-900">{value}</p>
+          <div key={label} className="bg-white/60 rounded-lg px-3 py-2">
+            <p className="text-[10px] font-semibold text-blue-400 uppercase tracking-wide">{label}</p>
+            <p className="text-xs font-medium text-blue-900 mt-0.5">{value}</p>
           </div>
         ))}
       </div>
       {charter.holidayDescription && (
-        <div className="bg-blue-50/60 rounded-xl px-4 py-3">
-          <p className="text-xs font-semibold text-blue-400 uppercase tracking-wide mb-1">Your Holiday Vision</p>
-          <p className="text-sm text-blue-800 italic">&ldquo;{charter.holidayDescription}&rdquo;</p>
+        <div className="bg-blue-50/60 rounded-lg px-3 py-2">
+          <p className="text-[10px] font-semibold text-blue-400 uppercase tracking-wide">Holiday Vision</p>
+          <p className="text-xs text-blue-800 italic mt-0.5">&ldquo;{charter.holidayDescription}&rdquo;</p>
         </div>
       )}
     </div>
@@ -313,10 +364,11 @@ function BookingOverview({ charter }: { charter: Charter }) {
 // Step 1: Crew
 // ---------------------------------------------------------------------------
 
-function CrewStep({ count, initial, onSave }: {
+function CrewStep({ count, initial, onSave, onAutoSave }: {
   count: number;
   initial: CrewMember[];
   onSave: (crew: CrewMember[]) => Promise<void>;
+  onAutoSave: (crew: CrewMember[]) => Promise<void>;
 }) {
   const empty = (): CrewMember => ({
     firstName: '', lastName: '', gender: '', dateOfBirth: '',
@@ -329,6 +381,7 @@ function CrewStep({ count, initial, onSave }: {
   });
   const [saving, setSaving] = useState(false);
   const [expanded, setExpanded] = useState(0);
+  const autoStatus = useAutoSave(crew, onAutoSave);
 
   function update(i: number, field: keyof CrewMember, val: string) {
     setCrew(prev => prev.map((m, idx) => idx === i ? { ...m, [field]: val } : m));
@@ -340,33 +393,29 @@ function CrewStep({ count, initial, onSave }: {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-2">
+      <div className="flex justify-end mb-1"><AutoSaveIndicator status={autoStatus} /></div>
       {crew.map((m, i) => (
-        <div key={i} className="bg-white/70 border border-blue-100 rounded-2xl overflow-hidden">
+        <div key={i} className="bg-white/70 border border-blue-100 rounded-xl overflow-hidden">
           <button
             type="button"
             onClick={() => setExpanded(expanded === i ? -1 : i)}
-            className="w-full flex items-center justify-between px-5 py-4 text-left"
+            className="w-full flex items-center justify-between px-4 py-3 text-left"
           >
             <div>
-              <span className="text-xs font-semibold text-blue-400 uppercase tracking-wide">
-                Passenger {i + 1}
-              </span>
-              <p className="text-sm font-semibold text-blue-900 mt-0.5">
+              <span className="text-[10px] font-bold text-blue-400 uppercase tracking-wide">Passenger {i + 1}</span>
+              <p className="text-xs font-semibold text-blue-900 mt-0.5">
                 {m.firstName || m.lastName ? `${m.firstName} ${m.lastName}`.trim() : 'Fill in details below'}
               </p>
             </div>
-            <svg
-              className={`w-5 h-5 text-blue-400 transition-transform ${expanded === i ? 'rotate-180' : ''}`}
-              fill="none" stroke="currentColor" viewBox="0 0 24 24"
-            >
+            <svg className={`w-4 h-4 text-blue-400 transition-transform ${expanded === i ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
             </svg>
           </button>
 
           {expanded === i && (
-            <div className="px-5 pb-5 space-y-4 border-t border-blue-100">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-4">
+            <div className="px-4 pb-4 space-y-3 border-t border-blue-100">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-3">
                 <div>
                   <FieldLabel>First Name</FieldLabel>
                   <TextInput value={m.firstName} onChange={v => update(i, 'firstName', v)} placeholder="First name" />
@@ -425,21 +474,23 @@ function CrewStep({ count, initial, onSave }: {
 // Step 2: Travel & Logistics
 // ---------------------------------------------------------------------------
 
-function TravelStep({ initial, onSave }: {
+function TravelStep({ initial, onSave, onAutoSave }: {
   initial: TravelLogistics;
   onSave: (travel: TravelLogistics) => Promise<void>;
+  onAutoSave: (travel: TravelLogistics) => Promise<void>;
 }) {
   const [data, setData] = useState<TravelLogistics>(initial);
   const [saving, setSaving] = useState(false);
+  const autoStatus = useAutoSave(data, onAutoSave);
   function set<K extends keyof TravelLogistics>(k: K, v: TravelLogistics[K]) {
     setData(prev => ({ ...prev, [k]: v }));
   }
   async function handleSave() { setSaving(true); try { await onSave(data); } finally { setSaving(false); } }
 
   return (
-    <div className="space-y-4">
-      <SectionCard title="Arrival">
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+    <div className="space-y-3">
+      <SectionCard title="Arrival" autoSave={autoStatus}>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
           <div>
             <FieldLabel>Arrival Date</FieldLabel>
             <TextInput value={data.arrivalDate ?? ''} onChange={v => set('arrivalDate', v)} type="date" />
@@ -478,7 +529,7 @@ function TravelStep({ initial, onSave }: {
       </SectionCard>
 
       <SectionCard title="Departure">
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
           <div>
             <FieldLabel>Departure Date</FieldLabel>
             <TextInput value={data.departureDate ?? ''} onChange={v => set('departureDate', v)} type="date" />
@@ -513,20 +564,22 @@ function TravelStep({ initial, onSave }: {
 // Step 3: Activities & Health
 // ---------------------------------------------------------------------------
 
-function ActivitiesStep({ initial, onSave }: {
+function ActivitiesStep({ initial, onSave, onAutoSave }: {
   initial: ActivityPreferences;
   onSave: (data: ActivityPreferences) => Promise<void>;
+  onAutoSave: (data: ActivityPreferences) => Promise<void>;
 }) {
   const [data, setData] = useState<ActivityPreferences>(initial);
   const [saving, setSaving] = useState(false);
+  const autoStatus = useAutoSave(data, onAutoSave);
   function set<K extends keyof ActivityPreferences>(k: K, v: ActivityPreferences[K]) {
     setData(prev => ({ ...prev, [k]: v }));
   }
   async function handleSave() { setSaving(true); try { await onSave(data); } finally { setSaving(false); } }
 
   return (
-    <div className="space-y-4">
-      <SectionCard title="Group Style">
+    <div className="space-y-3">
+      <SectionCard title="Group Style" autoSave={autoStatus}>
         <PillToggle
           options={[
             { id: 'active', label: 'Active & on the go' },
@@ -587,12 +640,14 @@ function ActivitiesStep({ initial, onSave }: {
 // Step 4: Food preferences
 // ---------------------------------------------------------------------------
 
-function FoodStep({ initial, onSave }: {
+function FoodStep({ initial, onSave, onAutoSave }: {
   initial: FoodPreferences;
   onSave: (food: FoodPreferences) => Promise<void>;
+  onAutoSave: (food: FoodPreferences) => Promise<void>;
 }) {
   const [data, setData] = useState<FoodPreferences>(initial);
   const [saving, setSaving] = useState(false);
+  const autoStatus = useAutoSave(data, onAutoSave);
 
   function setCategory(cat: string, field: 'likes' | 'dislikes' | 'allergies', val: string) {
     setData(prev => ({
@@ -620,17 +675,17 @@ function FoodStep({ initial, onSave }: {
   type CatKey = Lowercase<typeof FOOD_CATEGORIES[number]>;
 
   return (
-    <div className="space-y-4">
-      <SectionCard title="Food Preferences by Category">
+    <div className="space-y-3">
+      <SectionCard title="Food Preferences by Category" autoSave={autoStatus}>
         <p className="text-xs text-blue-500">Help us plan menus tailored to your group</p>
-        <div className="space-y-4">
+        <div className="space-y-2">
           {FOOD_CATEGORIES.map(cat => {
             const key = cat.toLowerCase() as CatKey;
             const catData = (data[key as keyof FoodPreferences] as { likes?: string; dislikes?: string; allergies?: string }) ?? {};
             return (
-              <div key={cat} className="border border-blue-100 rounded-xl p-4 space-y-3">
-                <p className="text-sm font-semibold text-blue-800">{cat}</p>
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <div key={cat} className="border border-blue-100 rounded-lg p-3 space-y-2">
+                <p className="text-xs font-bold text-blue-800">{cat}</p>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
                   <div>
                     <FieldLabel>Likes</FieldLabel>
                     <TextInput value={catData.likes ?? ''} onChange={v => setCategory(key, 'likes', v)} placeholder="e.g. grilled fish" />
@@ -773,12 +828,14 @@ function BeverageRow({ label, item, onChange }: {
   );
 }
 
-function BeveragesStep({ initial, onSave }: {
+function BeveragesStep({ initial, onSave, onAutoSave }: {
   initial: BeveragePreferences;
   onSave: (bev: BeveragePreferences) => Promise<void>;
+  onAutoSave: (bev: BeveragePreferences) => Promise<void>;
 }) {
   const [data, setData] = useState<BeveragePreferences>(initial);
   const [saving, setSaving] = useState(false);
+  const autoStatus = useAutoSave(data, onAutoSave);
 
   function updateRow(group: 'sodas' | 'wines' | 'spirits', key: string, val: { preferredBrand?: string; qty?: number; remarks?: string }) {
     setData(prev => ({ ...prev, [group]: { ...(prev[group] ?? {}), [key]: val } }));
@@ -787,8 +844,8 @@ function BeveragesStep({ initial, onSave }: {
   async function handleSave() { setSaving(true); try { await onSave(data); } finally { setSaving(false); } }
 
   return (
-    <div className="space-y-4">
-      <SectionCard title="Hot Beverages">
+    <div className="space-y-3">
+      <SectionCard title="Hot Beverages" autoSave={autoStatus}>
         <MultiChip
           options={WARM_BEVERAGES}
           values={data.warmBeverages ?? []}
@@ -837,15 +894,17 @@ function BeveragesStep({ initial, onSave }: {
 // Step 6: Special requests + checklist
 // ---------------------------------------------------------------------------
 
-function SpecialStep({ initial, checklistInit, onSave, onChecklistChange }: {
+function SpecialStep({ initial, checklistInit, onSave, onAutoSave, onChecklistChange }: {
   initial: SpecialRequests;
   checklistInit: Record<string, boolean>;
   onSave: (data: SpecialRequests) => Promise<void>;
+  onAutoSave: (data: SpecialRequests) => Promise<void>;
   onChecklistChange: (checklist: Record<string, boolean>) => void;
 }) {
   const [data, setData] = useState<SpecialRequests>(initial);
   const [checklist, setChecklist] = useState<Record<string, boolean>>(checklistInit);
   const [saving, setSaving] = useState(false);
+  const autoStatus = useAutoSave(data, onAutoSave);
 
   function set<K extends keyof SpecialRequests>(k: K, v: SpecialRequests[K]) {
     setData(prev => ({ ...prev, [k]: v }));
@@ -863,9 +922,9 @@ function SpecialStep({ initial, checklistInit, onSave, onChecklistChange }: {
   async function handleSave() { setSaving(true); try { await onSave(data); } finally { setSaving(false); } }
 
   return (
-    <div className="space-y-4">
-      <SectionCard title="Special Requests">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <div className="space-y-3">
+      <SectionCard title="Special Requests" autoSave={autoStatus}>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
             <FieldLabel>Special Occasion</FieldLabel>
             <TextInput
@@ -974,6 +1033,10 @@ export default function ClientSpaceClient({ token }: Props) {
   const [currentStep, setCurrentStep] = useState(0);
   const [toast, setToast] = useState<string | null>(null);
   const checklistRef = useRef<Record<string, boolean>>({});
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [history, setHistory] = useState<PrepSnapshot[]>([]);
+  const [loadingHistory, setLoadingHistory] = useState(false);
+  const [restoring, setRestoring] = useState<string | null>(null);
 
   useEffect(() => {
     Promise.all([
@@ -993,9 +1056,38 @@ export default function ClientSpaceClient({ token }: Props) {
 
   const showToast = useCallback((msg: string) => setToast(msg), []);
 
-  async function handleSaveCrew(crew: CrewMember[]) {
+  // Auto-save (no snapshot, no step advance, no toast)
+  async function autoSaveCrew(crew: CrewMember[]) {
     await saveCrew(token, crew);
     setPrep(prev => prev ? { ...prev, crew } : prev);
+  }
+  async function autoSaveTravel(travel: TravelLogistics) {
+    await saveTravel(token, travel);
+    setPrep(prev => prev ? { ...prev, travel } : prev);
+  }
+  async function autoSaveActivities(activities: ActivityPreferences) {
+    await saveActivities(token, activities);
+    setPrep(prev => prev ? { ...prev, activities } : prev);
+  }
+  async function autoSaveFood(food: FoodPreferences) {
+    await saveFood(token, food);
+    setPrep(prev => prev ? { ...prev, food } : prev);
+  }
+  async function autoSaveBeverages(beverages: BeveragePreferences) {
+    await saveBeverages(token, beverages);
+    setPrep(prev => prev ? { ...prev, beverages } : prev);
+  }
+  async function autoSaveSpecial(special: SpecialRequests) {
+    await saveSpecial(token, special);
+    setPrep(prev => prev ? { ...prev, special } : prev);
+  }
+
+  // Manual save (snapshot + step advance + toast)
+  async function handleSaveCrew(crew: CrewMember[]) {
+    await saveCrew(token, crew);
+    const updated = prep ? { ...prep, crew } : null;
+    setPrep(updated);
+    if (updated) await saveSnapshot(token, updated, 'Crew details');
     await saveStep(token, Math.max(currentStep, 1));
     setCurrentStep(s => Math.max(s, 1));
     showToast('Crew details saved ✓');
@@ -1003,7 +1095,9 @@ export default function ClientSpaceClient({ token }: Props) {
 
   async function handleSaveTravel(travel: TravelLogistics) {
     await saveTravel(token, travel);
-    setPrep(prev => prev ? { ...prev, travel } : prev);
+    const updated = prep ? { ...prep, travel } : null;
+    setPrep(updated);
+    if (updated) await saveSnapshot(token, updated, 'Travel & logistics');
     await saveStep(token, Math.max(currentStep, 2));
     setCurrentStep(s => Math.max(s, 2));
     showToast('Travel details saved ✓');
@@ -1011,7 +1105,9 @@ export default function ClientSpaceClient({ token }: Props) {
 
   async function handleSaveActivities(activities: ActivityPreferences) {
     await saveActivities(token, activities);
-    setPrep(prev => prev ? { ...prev, activities } : prev);
+    const updated = prep ? { ...prep, activities } : null;
+    setPrep(updated);
+    if (updated) await saveSnapshot(token, updated, 'Activities & health');
     await saveStep(token, Math.max(currentStep, 3));
     setCurrentStep(s => Math.max(s, 3));
     showToast('Activities & health saved ✓');
@@ -1019,7 +1115,9 @@ export default function ClientSpaceClient({ token }: Props) {
 
   async function handleSaveFood(food: FoodPreferences) {
     await saveFood(token, food);
-    setPrep(prev => prev ? { ...prev, food } : prev);
+    const updated = prep ? { ...prep, food } : null;
+    setPrep(updated);
+    if (updated) await saveSnapshot(token, updated, 'Food preferences');
     await saveStep(token, Math.max(currentStep, 4));
     setCurrentStep(s => Math.max(s, 4));
     showToast('Food preferences saved ✓');
@@ -1027,7 +1125,9 @@ export default function ClientSpaceClient({ token }: Props) {
 
   async function handleSaveBeverages(beverages: BeveragePreferences) {
     await saveBeverages(token, beverages);
-    setPrep(prev => prev ? { ...prev, beverages } : prev);
+    const updated = prep ? { ...prep, beverages } : null;
+    setPrep(updated);
+    if (updated) await saveSnapshot(token, updated, 'Beverages & bar');
     await saveStep(token, Math.max(currentStep, 5));
     setCurrentStep(s => Math.max(s, 5));
     showToast('Beverage preferences saved ✓');
@@ -1035,7 +1135,9 @@ export default function ClientSpaceClient({ token }: Props) {
 
   async function handleSaveSpecial(special: SpecialRequests) {
     await saveSpecial(token, special);
-    setPrep(prev => prev ? { ...prev, special } : prev);
+    const updated = prep ? { ...prep, special } : null;
+    setPrep(updated);
+    if (updated) await saveSnapshot(token, updated, 'Special requests');
     await saveStep(token, 6);
     setCurrentStep(6);
     showToast('All details saved — thank you! ✓');
@@ -1044,6 +1146,34 @@ export default function ClientSpaceClient({ token }: Props) {
   function handleChecklistChange(checklist: Record<string, boolean>) {
     checklistRef.current = checklist;
     saveChecklist(token, checklist).catch(console.error);
+  }
+
+  async function openHistory() {
+    setHistoryOpen(true);
+    setLoadingHistory(true);
+    try {
+      const h = await getHistory(token);
+      setHistory(h);
+    } finally {
+      setLoadingHistory(false);
+    }
+  }
+
+  async function handleRestore(snapshot: PrepSnapshot) {
+    if (!window.confirm('Restore this version? Your current data will be replaced.')) return;
+    setRestoring(snapshot.id);
+    try {
+      await restoreSnapshot(token, snapshot);
+      const p = await getClientPreparation(token);
+      if (p) {
+        setPrep(p);
+        checklistRef.current = p.checklist ?? {};
+      }
+      setHistoryOpen(false);
+      showToast('Previous version restored ✓');
+    } finally {
+      setRestoring(null);
+    }
   }
 
   // Loading
@@ -1089,16 +1219,29 @@ export default function ClientSpaceClient({ token }: Props) {
               <p className="text-white text-sm font-semibold leading-tight">Holiday Preparation</p>
               {charter.name && <p className="text-blue-300 text-xs truncate">Welcome, {charter.name}</p>}
             </div>
-            <a
-              href={`/client-space/${token}/summary`}
-              className="flex-shrink-0 px-3 py-1.5 rounded-xl text-xs font-semibold bg-white/15 hover:bg-white/25 text-white border border-white/20 transition-colors flex items-center gap-1.5"
-              title="View full summary"
-            >
-              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
-              Summary
-            </a>
+            <div className="flex items-center gap-1.5 flex-shrink-0">
+              <button
+                type="button"
+                onClick={openHistory}
+                className="px-3 py-1.5 rounded-xl text-xs font-semibold bg-white/15 hover:bg-white/25 text-white border border-white/20 transition-colors flex items-center gap-1.5"
+                title="View edit history"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                History
+              </button>
+              <a
+                href={`/client-space/${token}/summary`}
+                className="px-3 py-1.5 rounded-xl text-xs font-semibold bg-white/15 hover:bg-white/25 text-white border border-white/20 transition-colors flex items-center gap-1.5"
+                title="View full summary"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+                Summary
+              </a>
+            </div>
           </div>
           <StepIndicator current={currentStep} />
         </div>
@@ -1152,23 +1295,23 @@ export default function ClientSpaceClient({ token }: Props) {
         )}
 
         {currentStep === 1 && (
-          <CrewStep count={passengerCount} initial={prep.crew} onSave={handleSaveCrew} />
+          <CrewStep count={passengerCount} initial={prep.crew} onSave={handleSaveCrew} onAutoSave={autoSaveCrew} />
         )}
 
         {currentStep === 2 && (
-          <TravelStep initial={prep.travel} onSave={handleSaveTravel} />
+          <TravelStep initial={prep.travel} onSave={handleSaveTravel} onAutoSave={autoSaveTravel} />
         )}
 
         {currentStep === 3 && (
-          <ActivitiesStep initial={prep.activities} onSave={handleSaveActivities} />
+          <ActivitiesStep initial={prep.activities} onSave={handleSaveActivities} onAutoSave={autoSaveActivities} />
         )}
 
         {currentStep === 4 && (
-          <FoodStep initial={prep.food} onSave={handleSaveFood} />
+          <FoodStep initial={prep.food} onSave={handleSaveFood} onAutoSave={autoSaveFood} />
         )}
 
         {currentStep === 5 && (
-          <BeveragesStep initial={prep.beverages} onSave={handleSaveBeverages} />
+          <BeveragesStep initial={prep.beverages} onSave={handleSaveBeverages} onAutoSave={autoSaveBeverages} />
         )}
 
         {currentStep === 6 && (
@@ -1176,6 +1319,7 @@ export default function ClientSpaceClient({ token }: Props) {
             initial={prep.special}
             checklistInit={prep.checklist ?? {}}
             onSave={handleSaveSpecial}
+            onAutoSave={autoSaveSpecial}
             onChecklistChange={handleChecklistChange}
           />
         )}
@@ -1227,6 +1371,66 @@ export default function ClientSpaceClient({ token }: Props) {
       </div>
 
       {toast && <Toast msg={toast} onDone={() => setToast(null)} />}
+
+      {/* History drawer */}
+      {historyOpen && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
+            onClick={() => setHistoryOpen(false)}
+          />
+          {/* Panel */}
+          <div className="fixed top-0 right-0 h-full w-full max-w-sm z-50 bg-[#002a5a] border-l border-white/10 shadow-2xl flex flex-col">
+            <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
+              <div>
+                <h2 className="text-white font-bold text-base">Edit History</h2>
+                <p className="text-blue-300 text-xs mt-0.5">Restore any previous version</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setHistoryOpen(false)}
+                className="w-8 h-8 rounded-full bg-white/10 hover:bg-white/20 text-white flex items-center justify-center transition-colors"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto p-4 space-y-2">
+              {loadingHistory && (
+                <div className="flex items-center justify-center py-12">
+                  <div className="animate-spin w-6 h-6 border-2 border-white/20 border-t-white rounded-full" />
+                </div>
+              )}
+              {!loadingHistory && history.length === 0 && (
+                <div className="text-center py-12">
+                  <p className="text-4xl mb-3">📋</p>
+                  <p className="text-blue-300 text-sm">No history yet.</p>
+                  <p className="text-blue-400 text-xs mt-1">Snapshots are saved each time you click &ldquo;Save&rdquo;.</p>
+                </div>
+              )}
+              {!loadingHistory && history.map(snap => (
+                <div key={snap.id} className="bg-white/8 border border-white/10 rounded-xl p-3.5 space-y-2">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="text-white text-xs font-semibold truncate">{snap.label}</p>
+                      <p className="text-blue-400 text-[10px] mt-0.5">{fmtDateTime(snap.savedAt)}</p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleRestore(snap)}
+                      disabled={restoring === snap.id}
+                      className="flex-shrink-0 px-3 py-1 rounded-lg text-[11px] font-semibold bg-blue-500/30 hover:bg-blue-500/50 text-blue-200 border border-blue-400/30 transition-colors disabled:opacity-50"
+                    >
+                      {restoring === snap.id ? 'Restoring…' : 'Restore'}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/app/client-space/[token]/ClientSpaceClient.tsx
+++ b/app/client-space/[token]/ClientSpaceClient.tsx
@@ -161,8 +161,10 @@ function Toast({ msg, onDone }: { msg: string; onDone: () => void }) {
 // Reusable field components
 // ---------------------------------------------------------------------------
 
+const inputBase = 'w-full rounded-xl border border-blue-200 bg-white px-3 py-2 text-sm text-blue-900 placeholder:text-blue-300 transition-all focus:outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-200/60 shadow-sm hover:border-blue-300';
+
 function FieldLabel({ children }: { children: ReactNode }) {
-  return <label className="block text-xs font-semibold text-blue-800 mb-1">{children}</label>;
+  return <label className="block text-xs font-semibold text-blue-700 uppercase tracking-wide mb-1.5">{children}</label>;
 }
 
 function TextInput({ value, onChange, placeholder, type = 'text' }: {
@@ -174,7 +176,7 @@ function TextInput({ value, onChange, placeholder, type = 'text' }: {
       value={value}
       onChange={e => onChange(e.target.value)}
       placeholder={placeholder}
-      className="w-full border border-blue-200 rounded-lg px-2.5 py-1.5 text-xs text-blue-900 focus:outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200 bg-white/90"
+      className={inputBase}
     />
   );
 }
@@ -188,7 +190,7 @@ function TextArea({ value, onChange, placeholder, rows = 3 }: {
       onChange={e => onChange(e.target.value)}
       placeholder={placeholder}
       rows={rows}
-      className="w-full border border-blue-200 rounded-lg px-2.5 py-1.5 text-xs text-blue-900 focus:outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200 bg-white/90 resize-none"
+      className={`${inputBase} resize-none leading-relaxed`}
     />
   );
 }
@@ -200,7 +202,7 @@ function SelectInput({ value, onChange, options, placeholder }: {
     <select
       value={value}
       onChange={e => onChange(e.target.value)}
-      className="w-full border border-blue-200 rounded-lg px-2.5 py-1.5 text-xs text-blue-900 focus:outline-none focus:border-blue-400 bg-white/90"
+      className={inputBase}
     >
       {placeholder && <option value="">{placeholder}</option>}
       {options.map(o => <option key={o} value={o}>{o}</option>)}
@@ -214,16 +216,16 @@ function PillToggle({ options, value, onChange }: {
   onChange: (v: string) => void;
 }) {
   return (
-    <div className="flex flex-wrap gap-1.5">
+    <div className="flex flex-wrap gap-2">
       {options.map(o => (
         <button
           key={o.id}
           type="button"
           onClick={() => onChange(value === o.id ? '' : o.id)}
-          className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all border ${
+          className={`px-4 py-2 rounded-xl text-xs font-semibold transition-all border shadow-sm ${
             value === o.id
-              ? 'bg-blue-600 border-blue-600 text-white'
-              : 'bg-white border-blue-200 text-blue-700 hover:border-blue-400'
+              ? 'bg-blue-600 border-blue-600 text-white shadow-blue-200'
+              : 'bg-white border-blue-200 text-blue-700 hover:border-blue-400 hover:bg-blue-50'
           }`}
         >
           {o.label}
@@ -242,21 +244,68 @@ function MultiChip({ options, values, onChange }: {
     onChange(values.includes(opt) ? values.filter(v => v !== opt) : [...values, opt]);
   }
   return (
-    <div className="flex flex-wrap gap-1.5">
+    <div className="flex flex-wrap gap-2">
       {options.map(o => (
         <button
           key={o}
           type="button"
           onClick={() => toggle(o)}
-          className={`px-2.5 py-1 rounded-full text-xs font-medium transition-all border ${
+          className={`px-3 py-1.5 rounded-xl text-xs font-semibold transition-all border shadow-sm ${
             values.includes(o)
               ? 'bg-blue-600 border-blue-600 text-white'
-              : 'bg-white border-blue-200 text-blue-600 hover:border-blue-400'
+              : 'bg-white border-blue-200 text-blue-600 hover:border-blue-400 hover:bg-blue-50'
           }`}
         >
           {o}
         </button>
       ))}
+    </div>
+  );
+}
+
+function PassengerNotes({ crew, notes, onChange }: {
+  crew: CrewMember[];
+  notes: Record<string, string>;
+  onChange: (notes: Record<string, string>) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  if (crew.length === 0) return null;
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="flex items-center gap-1.5 text-[11px] font-semibold text-blue-500 hover:text-blue-700 transition-colors"
+      >
+        <svg className={`w-3 h-3 transition-transform ${open ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+        Per passenger details
+        {Object.values(notes).some(Boolean) && (
+          <span className="ml-1 w-4 h-4 rounded-full bg-blue-500 text-white text-[9px] flex items-center justify-center">
+            {Object.values(notes).filter(Boolean).length}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div className="mt-2 space-y-2 pl-2 border-l-2 border-blue-100">
+          {crew.map((m, i) => {
+            const name = [m.firstName, m.lastName].filter(Boolean).join(' ') || `Passenger ${i + 1}`;
+            return (
+              <div key={i} className="flex items-center gap-2">
+                <span className="text-[11px] font-medium text-blue-600 w-28 flex-shrink-0 truncate">{name}</span>
+                <input
+                  type="text"
+                  value={notes[String(i)] ?? ''}
+                  onChange={e => onChange({ ...notes, [String(i)]: e.target.value })}
+                  placeholder="Specific note…"
+                  className="flex-1 rounded-lg border border-blue-200 bg-white/80 px-2.5 py-1.5 text-xs text-blue-900 placeholder:text-blue-300 focus:outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200/60 transition-all"
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }
@@ -272,9 +321,9 @@ function AutoSaveIndicator({ status }: { status: 'idle' | 'saving' | 'saved' }) 
 
 function SectionCard({ title, autoSave, children }: { title: string; autoSave?: 'idle' | 'saving' | 'saved'; children: ReactNode }) {
   return (
-    <div className="bg-white/70 backdrop-blur-sm border border-blue-100 rounded-xl p-3 space-y-3">
+    <div className="bg-white/80 backdrop-blur-sm border border-blue-100 rounded-2xl p-4 space-y-4 shadow-sm">
       <div className="flex items-center justify-between">
-        <h3 className="text-sm font-bold text-blue-900">{title}</h3>
+        <h3 className="text-sm font-bold text-blue-900 tracking-tight">{title}</h3>
         {autoSave && <AutoSaveIndicator status={autoSave} />}
       </div>
       {children}
@@ -640,8 +689,9 @@ function ActivitiesStep({ initial, onSave, onAutoSave }: {
 // Step 4: Food preferences
 // ---------------------------------------------------------------------------
 
-function FoodStep({ initial, onSave, onAutoSave }: {
+function FoodStep({ initial, crew, onSave, onAutoSave }: {
   initial: FoodPreferences;
+  crew: CrewMember[];
   onSave: (food: FoodPreferences) => Promise<void>;
   onAutoSave: (food: FoodPreferences) => Promise<void>;
 }) {
@@ -649,7 +699,7 @@ function FoodStep({ initial, onSave, onAutoSave }: {
   const [saving, setSaving] = useState(false);
   const autoStatus = useAutoSave(data, onAutoSave);
 
-  function setCategory(cat: string, field: 'likes' | 'dislikes' | 'allergies', val: string) {
+  function setCategory(cat: string, field: 'likes' | 'dislikes' | 'allergies' | 'passengerNotes', val: string | Record<string, string>) {
     setData(prev => ({
       ...prev,
       [cat]: { ...(prev[cat as keyof FoodPreferences] as object ?? {}), [field]: val },
@@ -683,8 +733,8 @@ function FoodStep({ initial, onSave, onAutoSave }: {
             const key = cat.toLowerCase() as CatKey;
             const catData = (data[key as keyof FoodPreferences] as { likes?: string; dislikes?: string; allergies?: string }) ?? {};
             return (
-              <div key={cat} className="border border-blue-100 rounded-lg p-3 space-y-2">
-                <p className="text-xs font-bold text-blue-800">{cat}</p>
+              <div key={cat} className="border border-blue-100 rounded-xl p-3 space-y-3 bg-white/50">
+                <p className="text-xs font-bold text-blue-800 uppercase tracking-wide">{cat}</p>
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
                   <div>
                     <FieldLabel>Likes</FieldLabel>
@@ -699,6 +749,11 @@ function FoodStep({ initial, onSave, onAutoSave }: {
                     <TextInput value={catData.allergies ?? ''} onChange={v => setCategory(key, 'allergies', v)} placeholder="e.g. shellfish allergy" />
                   </div>
                 </div>
+                <PassengerNotes
+                  crew={crew}
+                  notes={(catData as { passengerNotes?: Record<string, string> }).passengerNotes ?? {}}
+                  onChange={notes => setCategory(key, 'passengerNotes', notes)}
+                />
               </div>
             );
           })}
@@ -801,35 +856,45 @@ function FoodStep({ initial, onSave, onAutoSave }: {
 // Step 5: Beverages
 // ---------------------------------------------------------------------------
 
-function BeverageRow({ label, item, onChange }: {
+function BeverageRow({ label, item, crew, onChange }: {
   label: string;
-  item: { preferredBrand?: string; qty?: number; remarks?: string };
-  onChange: (v: { preferredBrand?: string; qty?: number; remarks?: string }) => void;
+  item: { preferredBrand?: string; qty?: number; remarks?: string; passengerNotes?: Record<string, string> };
+  crew: CrewMember[];
+  onChange: (v: { preferredBrand?: string; qty?: number; remarks?: string; passengerNotes?: Record<string, string> }) => void;
 }) {
+  const inputCell = 'rounded-lg border border-blue-200 bg-white px-2.5 py-2 text-xs text-blue-900 placeholder:text-blue-300 focus:outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200/60 transition-all shadow-sm hover:border-blue-300 w-full';
   return (
-    <div className="grid grid-cols-3 sm:grid-cols-[2fr_1fr_2fr] gap-2 items-center py-2 border-b border-blue-50 last:border-0">
-      <span className="text-xs font-medium text-blue-800">{label}</span>
-      <input
-        type="number"
-        min={0}
-        placeholder="Qty"
-        value={item.qty ?? ''}
-        onChange={e => onChange({ ...item, qty: e.target.value ? Number(e.target.value) : undefined })}
-        className="border border-blue-100 rounded-lg px-2 py-1.5 text-xs text-blue-900 focus:outline-none focus:border-blue-400 bg-white/80 w-full"
-      />
-      <input
-        type="text"
-        placeholder="Brand / remarks"
-        value={item.preferredBrand ?? ''}
-        onChange={e => onChange({ ...item, preferredBrand: e.target.value })}
-        className="border border-blue-100 rounded-lg px-2 py-1.5 text-xs text-blue-900 focus:outline-none focus:border-blue-400 bg-white/80 w-full"
+    <div className="py-2.5 border-b border-blue-50 last:border-0">
+      <div className="grid grid-cols-[2fr_1fr_2fr] gap-2 items-center">
+        <span className="text-xs font-semibold text-blue-800">{label}</span>
+        <input
+          type="number"
+          min={0}
+          placeholder="Qty"
+          value={item.qty ?? ''}
+          onChange={e => onChange({ ...item, qty: e.target.value ? Number(e.target.value) : undefined })}
+          className={inputCell}
+        />
+        <input
+          type="text"
+          placeholder="Brand / remarks"
+          value={item.preferredBrand ?? ''}
+          onChange={e => onChange({ ...item, preferredBrand: e.target.value })}
+          className={inputCell}
+        />
+      </div>
+      <PassengerNotes
+        crew={crew}
+        notes={item.passengerNotes ?? {}}
+        onChange={notes => onChange({ ...item, passengerNotes: notes })}
       />
     </div>
   );
 }
 
-function BeveragesStep({ initial, onSave, onAutoSave }: {
+function BeveragesStep({ initial, crew, onSave, onAutoSave }: {
   initial: BeveragePreferences;
+  crew: CrewMember[];
   onSave: (bev: BeveragePreferences) => Promise<void>;
   onAutoSave: (bev: BeveragePreferences) => Promise<void>;
 }) {
@@ -877,6 +942,7 @@ function BeveragesStep({ initial, onSave, onAutoSave }: {
               key={t}
               label={t}
               item={(data[group] ?? {})[t] ?? {}}
+              crew={crew}
               onChange={v => updateRow(group, t, v)}
             />
           ))}
@@ -1307,11 +1373,11 @@ export default function ClientSpaceClient({ token }: Props) {
         )}
 
         {currentStep === 4 && (
-          <FoodStep initial={prep.food} onSave={handleSaveFood} onAutoSave={autoSaveFood} />
+          <FoodStep initial={prep.food} crew={prep.crew} onSave={handleSaveFood} onAutoSave={autoSaveFood} />
         )}
 
         {currentStep === 5 && (
-          <BeveragesStep initial={prep.beverages} onSave={handleSaveBeverages} onAutoSave={autoSaveBeverages} />
+          <BeveragesStep initial={prep.beverages} crew={prep.crew} onSave={handleSaveBeverages} onAutoSave={autoSaveBeverages} />
         )}
 
         {currentStep === 6 && (

--- a/app/client-space/[token]/ClientSpaceClient.tsx
+++ b/app/client-space/[token]/ClientSpaceClient.tsx
@@ -20,6 +20,7 @@ import {
   type ClientPreparation,
   type CrewMember,
   type TravelLogistics,
+  type TravelGroup,
   type ActivityPreferences,
   type FoodPreferences,
   type BeveragePreferences,
@@ -523,84 +524,264 @@ function CrewStep({ count, initial, onSave, onAutoSave }: {
 // Step 2: Travel & Logistics
 // ---------------------------------------------------------------------------
 
-function TravelStep({ initial, onSave, onAutoSave }: {
+function newGroup(id: string, memberIndices: number[]): TravelGroup {
+  return { id, memberIndices };
+}
+
+function initGroups(initial: TravelLogistics, passengerCount: number): TravelGroup[] {
+  if (initial.groups && initial.groups.length > 0) return initial.groups;
+  return [newGroup('g1', Array.from({ length: passengerCount }, (_, i) => i))];
+}
+
+function TableRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <tr className="border-t border-blue-100">
+      <td className="py-3 pr-4 text-xs font-semibold text-blue-500 uppercase tracking-wide whitespace-nowrap w-36 align-top pt-3.5">
+        {label}
+      </td>
+      {children}
+    </tr>
+  );
+}
+
+function TravelStep({ initial, crew, onSave, onAutoSave }: {
   initial: TravelLogistics;
+  crew: CrewMember[];
   onSave: (travel: TravelLogistics) => Promise<void>;
   onAutoSave: (travel: TravelLogistics) => Promise<void>;
 }) {
-  const [data, setData] = useState<TravelLogistics>(initial);
+  const passengerCount = Math.max(crew.length, 1);
+  const [groups, setGroups] = useState<TravelGroup[]>(() => initGroups(initial, passengerCount));
   const [saving, setSaving] = useState(false);
+
+  const data: TravelLogistics = { groups };
   const autoStatus = useAutoSave(data, onAutoSave);
-  function set<K extends keyof TravelLogistics>(k: K, v: TravelLogistics[K]) {
-    setData(prev => ({ ...prev, [k]: v }));
+
+  function updateGroup(id: string, patch: Partial<TravelGroup>) {
+    setGroups(prev => prev.map(g => g.id === id ? { ...g, ...patch } : g));
   }
-  async function handleSave() { setSaving(true); try { await onSave(data); } finally { setSaving(false); } }
+
+  function addGroup() {
+    const id = `g${Date.now()}`;
+    setGroups(prev => [...prev, newGroup(id, [])]);
+  }
+
+  function removeGroup(id: string) {
+    if (groups.length <= 1) return;
+    setGroups(prev => prev.filter(g => g.id !== id));
+  }
+
+  // Toggle a member between groups — exclusive: adding to one removes from others
+  function toggleMember(groupId: string, idx: number) {
+    setGroups(prev => {
+      const inGroup = prev.find(g => g.id === groupId)?.memberIndices.includes(idx);
+      return prev.map(g => {
+        if (g.id === groupId) {
+          return {
+            ...g,
+            memberIndices: inGroup
+              ? g.memberIndices.filter(i => i !== idx)
+              : [...g.memberIndices, idx].sort((a, b) => a - b),
+          };
+        }
+        // Remove from other groups (exclusive)
+        return { ...g, memberIndices: g.memberIndices.filter(i => i !== idx) };
+      });
+    });
+  }
+
+  function memberName(idx: number) {
+    const m = crew[idx];
+    if (!m) return `Passenger ${idx + 1}`;
+    const name = [m.firstName, m.lastName].filter(Boolean).join(' ');
+    return name || `Passenger ${idx + 1}`;
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    try { await onSave(data); } finally { setSaving(false); }
+  }
+
+  const colCount = groups.length;
 
   return (
-    <div className="space-y-3">
-      <SectionCard title="Arrival" autoSave={autoStatus}>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          <div>
-            <FieldLabel>Arrival Date</FieldLabel>
-            <TextInput value={data.arrivalDate ?? ''} onChange={v => set('arrivalDate', v)} type="date" />
-          </div>
-          <div>
-            <FieldLabel>Arrival Time</FieldLabel>
-            <TextInput value={data.arrivalTime ?? ''} onChange={v => set('arrivalTime', v)} type="time" />
-          </div>
-          <div>
-            <FieldLabel>Flight Number</FieldLabel>
-            <TextInput value={data.arrivalFlight ?? ''} onChange={v => set('arrivalFlight', v)} placeholder="e.g. EasyJet EZY1234" />
-          </div>
-        </div>
-        <div className="space-y-2">
-          <FieldLabel>Staying at a hotel before boarding?</FieldLabel>
-          <PillToggle
-            options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
-            value={data.stayingAtHotel ? 'yes' : data.stayingAtHotel === false ? 'no' : ''}
-            onChange={v => set('stayingAtHotel', v === 'yes')}
-          />
-          {data.stayingAtHotel && (
-            <div className="mt-2">
-              <FieldLabel>Hotel Name & Contact</FieldLabel>
-              <TextInput value={data.hotelName ?? ''} onChange={v => set('hotelName', v)} placeholder="Hotel name and phone/address" />
-            </div>
-          )}
-        </div>
-        <div className="space-y-2">
-          <FieldLabel>Airport transfer to marina needed?</FieldLabel>
-          <PillToggle
-            options={[{ id: 'yes', label: 'Yes — arrange please' }, { id: 'no', label: 'No — I\'ll arrange my own' }]}
-            value={data.transferFromAirport ? 'yes' : data.transferFromAirport === false ? 'no' : ''}
-            onChange={v => set('transferFromAirport', v === 'yes')}
-          />
-        </div>
-      </SectionCard>
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <AutoSaveIndicator status={autoStatus} />
+        <button
+          type="button"
+          onClick={addGroup}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-semibold bg-blue-600 text-white hover:bg-blue-700 transition-colors shadow-sm"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+          </svg>
+          Add Travel Group
+        </button>
+      </div>
 
-      <SectionCard title="Departure">
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          <div>
-            <FieldLabel>Departure Date</FieldLabel>
-            <TextInput value={data.departureDate ?? ''} onChange={v => set('departureDate', v)} type="date" />
-          </div>
-          <div>
-            <FieldLabel>Departure Time</FieldLabel>
-            <TextInput value={data.departureTime ?? ''} onChange={v => set('departureTime', v)} type="time" />
-          </div>
-          <div>
-            <FieldLabel>Flight Number</FieldLabel>
-            <TextInput value={data.departureFlight ?? ''} onChange={v => set('departureFlight', v)} placeholder="e.g. BA456" />
-          </div>
-        </div>
-        <div className="space-y-2">
-          <FieldLabel>Airport transfer from marina needed?</FieldLabel>
-          <PillToggle
-            options={[{ id: 'yes', label: 'Yes — arrange please' }, { id: 'no', label: 'No — I\'ll arrange my own' }]}
-            value={data.transferToAirport ? 'yes' : data.transferToAirport === false ? 'no' : ''}
-            onChange={v => set('transferToAirport', v === 'yes')}
-          />
-        </div>
-      </SectionCard>
+      <div className="bg-white/80 backdrop-blur-sm border border-blue-100 rounded-2xl shadow-sm overflow-x-auto">
+        <table className="w-full min-w-[480px]">
+          <thead>
+            <tr className="border-b border-blue-100">
+              <th className="py-3 pr-4 w-36" />
+              {groups.map((g, gi) => (
+                <th key={g.id} className="py-3 px-3 text-left">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm font-bold text-blue-900">Group {gi + 1}</span>
+                    {colCount > 1 && (
+                      <button
+                        type="button"
+                        onClick={() => removeGroup(g.id)}
+                        className="w-5 h-5 rounded-full bg-red-100 text-red-500 hover:bg-red-200 flex items-center justify-center text-[10px] transition-colors flex-shrink-0"
+                        title="Remove group"
+                      >✕</button>
+                    )}
+                  </div>
+                  <p className="text-[10px] text-blue-400 mt-0.5">
+                    {g.memberIndices.length === 0
+                      ? 'No members assigned'
+                      : g.memberIndices.length === passengerCount
+                      ? 'All passengers'
+                      : `${g.memberIndices.length} passenger${g.memberIndices.length > 1 ? 's' : ''}`}
+                  </p>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="px-4">
+
+            {/* Members row */}
+            <TableRow label="Members">
+              {groups.map(g => (
+                <td key={g.id} className="py-3 px-3 align-top">
+                  <div className="flex flex-wrap gap-1.5">
+                    {Array.from({ length: passengerCount }, (_, idx) => {
+                      const selected = g.memberIndices.includes(idx);
+                      return (
+                        <button
+                          key={idx}
+                          type="button"
+                          onClick={() => toggleMember(g.id, idx)}
+                          className={`px-2 py-1 rounded-lg text-[11px] font-semibold border transition-all ${
+                            selected
+                              ? 'bg-blue-600 border-blue-600 text-white'
+                              : 'bg-white border-blue-200 text-blue-500 hover:border-blue-400'
+                          }`}
+                        >
+                          {memberName(idx)}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </td>
+              ))}
+            </TableRow>
+
+            {/* ── ARRIVAL ── */}
+            <tr className="border-t-2 border-blue-200">
+              <td colSpan={colCount + 1} className="py-2 px-0">
+                <span className="text-[10px] font-bold text-blue-400 uppercase tracking-widest">Arrival</span>
+              </td>
+            </tr>
+
+            <TableRow label="Date">
+              {groups.map(g => (
+                <td key={g.id} className="py-2 px-3 align-top">
+                  <TextInput value={g.arrivalDate ?? ''} onChange={v => updateGroup(g.id, { arrivalDate: v })} type="date" />
+                </td>
+              ))}
+            </TableRow>
+
+            <TableRow label="Time">
+              {groups.map(g => (
+                <td key={g.id} className="py-2 px-3 align-top">
+                  <TextInput value={g.arrivalTime ?? ''} onChange={v => updateGroup(g.id, { arrivalTime: v })} type="time" />
+                </td>
+              ))}
+            </TableRow>
+
+            <TableRow label="Flight No.">
+              {groups.map(g => (
+                <td key={g.id} className="py-2 px-3 align-top">
+                  <TextInput value={g.arrivalFlight ?? ''} onChange={v => updateGroup(g.id, { arrivalFlight: v })} placeholder="e.g. EZY1234" />
+                </td>
+              ))}
+            </TableRow>
+
+            <TableRow label="Hotel before boarding?">
+              {groups.map(g => (
+                <td key={g.id} className="py-2 px-3 align-top space-y-2">
+                  <PillToggle
+                    options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
+                    value={g.stayingAtHotel ? 'yes' : g.stayingAtHotel === false ? 'no' : ''}
+                    onChange={v => updateGroup(g.id, { stayingAtHotel: v === 'yes' })}
+                  />
+                  {g.stayingAtHotel && (
+                    <TextInput value={g.hotelName ?? ''} onChange={v => updateGroup(g.id, { hotelName: v })} placeholder="Hotel name & contact" />
+                  )}
+                </td>
+              ))}
+            </TableRow>
+
+            <TableRow label="Transfer to marina?">
+              {groups.map(g => (
+                <td key={g.id} className="py-2 px-3 align-top">
+                  <PillToggle
+                    options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
+                    value={g.transferFromAirport ? 'yes' : g.transferFromAirport === false ? 'no' : ''}
+                    onChange={v => updateGroup(g.id, { transferFromAirport: v === 'yes' })}
+                  />
+                </td>
+              ))}
+            </TableRow>
+
+            {/* ── DEPARTURE ── */}
+            <tr className="border-t-2 border-blue-200">
+              <td colSpan={colCount + 1} className="py-2 px-0">
+                <span className="text-[10px] font-bold text-blue-400 uppercase tracking-widest">Departure</span>
+              </td>
+            </tr>
+
+            <TableRow label="Date">
+              {groups.map(g => (
+                <td key={g.id} className="py-2 px-3 align-top">
+                  <TextInput value={g.departureDate ?? ''} onChange={v => updateGroup(g.id, { departureDate: v })} type="date" />
+                </td>
+              ))}
+            </TableRow>
+
+            <TableRow label="Time">
+              {groups.map(g => (
+                <td key={g.id} className="py-2 px-3 align-top">
+                  <TextInput value={g.departureTime ?? ''} onChange={v => updateGroup(g.id, { departureTime: v })} type="time" />
+                </td>
+              ))}
+            </TableRow>
+
+            <TableRow label="Flight No.">
+              {groups.map(g => (
+                <td key={g.id} className="py-2 px-3 align-top">
+                  <TextInput value={g.departureFlight ?? ''} onChange={v => updateGroup(g.id, { departureFlight: v })} placeholder="e.g. BA456" />
+                </td>
+              ))}
+            </TableRow>
+
+            <TableRow label="Transfer to airport?">
+              {groups.map(g => (
+                <td key={g.id} className="py-2 px-3 align-top">
+                  <PillToggle
+                    options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
+                    value={g.transferToAirport ? 'yes' : g.transferToAirport === false ? 'no' : ''}
+                    onChange={v => updateGroup(g.id, { transferToAirport: v === 'yes' })}
+                  />
+                </td>
+              ))}
+            </TableRow>
+
+          </tbody>
+        </table>
+      </div>
 
       <div className="flex justify-end">
         <SaveButton onClick={handleSave} saving={saving} label="Save Travel Details" />
@@ -1365,7 +1546,7 @@ export default function ClientSpaceClient({ token }: Props) {
         )}
 
         {currentStep === 2 && (
-          <TravelStep initial={prep.travel} onSave={handleSaveTravel} onAutoSave={autoSaveTravel} />
+          <TravelStep initial={prep.travel} crew={prep.crew} onSave={handleSaveTravel} onAutoSave={autoSaveTravel} />
         )}
 
         {currentStep === 3 && (

--- a/app/client-space/[token]/ClientSpaceClient.tsx
+++ b/app/client-space/[token]/ClientSpaceClient.tsx
@@ -1280,6 +1280,7 @@ export default function ClientSpaceClient({ token }: Props) {
   const [currentStep, setCurrentStep] = useState(0);
   const [toast, setToast] = useState<string | null>(null);
   const checklistRef = useRef<Record<string, boolean>>({});
+  const stepNavRef = useRef<HTMLDivElement>(null);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [history, setHistory] = useState<PrepSnapshot[]>([]);
   const [loadingHistory, setLoadingHistory] = useState(false);
@@ -1300,6 +1301,13 @@ export default function ClientSpaceClient({ token }: Props) {
       .catch(() => setNotFound(true))
       .finally(() => setLoading(false));
   }, [token]);
+
+  // Scroll active step tab into view on mobile
+  useEffect(() => {
+    if (!stepNavRef.current) return;
+    const active = stepNavRef.current.children[currentStep] as HTMLElement | undefined;
+    active?.scrollIntoView?.({ block: 'nearest', inline: 'center', behavior: 'smooth' });
+  }, [currentStep]);
 
   const showToast = useCallback((msg: string) => setToast(msg), []);
 
@@ -1496,7 +1504,9 @@ export default function ClientSpaceClient({ token }: Props) {
 
       <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
         {/* Step nav buttons */}
-        <div className="flex gap-2 overflow-x-auto pb-1">
+        <div ref={stepNavRef} className="flex gap-2 overflow-x-auto pb-1 scroll-smooth"
+          style={{ scrollbarWidth: 'none' }}
+        >
           {STEPS.map((label, i) => (
             <button
               key={i}

--- a/app/client-space/[token]/ClientSpaceClient.tsx
+++ b/app/client-space/[token]/ClientSpaceClient.tsx
@@ -162,7 +162,7 @@ function Toast({ msg, onDone }: { msg: string; onDone: () => void }) {
 // Reusable field components
 // ---------------------------------------------------------------------------
 
-const inputBase = 'w-full bg-transparent border-0 border-b border-blue-300/60 rounded-none px-0 py-1.5 text-xs text-blue-900 placeholder:text-blue-300/70 transition-all focus:outline-none focus:border-blue-600 focus:ring-0';
+const inputBase = 'w-full appearance-none bg-transparent border-0 border-b border-blue-300/60 rounded-none px-0 py-1.5 text-xs text-blue-900 placeholder:text-blue-300/70 transition-all focus:outline-none focus:border-blue-600 focus:ring-0';
 
 function FieldLabel({ children }: { children: ReactNode }) {
   return <label className="block text-[10px] font-semibold text-blue-600 uppercase tracking-wide mb-1">{children}</label>;
@@ -623,9 +623,9 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
       {/* ── Mobile: stacked cards (< md) ── */}
       <div className="md:hidden space-y-4">
         {groups.map((g, gi) => (
-          <div key={g.id} className="bg-white/80 backdrop-blur-sm border border-blue-100 rounded-xl shadow-sm overflow-hidden">
+          <div key={g.id} className="border-b border-blue-100/60 pb-4">
             {/* Group header */}
-            <div className="flex items-center justify-between px-4 py-3 bg-blue-50/60 border-b border-blue-100">
+            <div className="flex items-center justify-between py-2">
               <div>
                 <span className="text-sm font-bold text-blue-900">Group {gi + 1}</span>
                 <span className="ml-2 text-[11px] text-blue-400">
@@ -637,7 +637,7 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
               )}
             </div>
 
-            <div className="px-4 py-3 space-y-4">
+            <div className="space-y-4">
               {/* Members */}
               <div>
                 <p className="text-[10px] font-semibold text-blue-400 uppercase tracking-wide mb-1.5">Members</p>

--- a/app/client-space/[token]/ClientSpaceClient.tsx
+++ b/app/client-space/[token]/ClientSpaceClient.tsx
@@ -620,7 +620,106 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
         </button>
       </div>
 
-      <div className="bg-white/80 backdrop-blur-sm border border-blue-100 rounded-xl shadow-sm overflow-x-auto">
+      {/* ── Mobile: stacked cards (< md) ── */}
+      <div className="md:hidden space-y-4">
+        {groups.map((g, gi) => (
+          <div key={g.id} className="bg-white/80 backdrop-blur-sm border border-blue-100 rounded-xl shadow-sm overflow-hidden">
+            {/* Group header */}
+            <div className="flex items-center justify-between px-4 py-3 bg-blue-50/60 border-b border-blue-100">
+              <div>
+                <span className="text-sm font-bold text-blue-900">Group {gi + 1}</span>
+                <span className="ml-2 text-[11px] text-blue-400">
+                  {g.memberIndices.length === 0 ? 'No members' : g.memberIndices.length === passengerCount ? 'All passengers' : `${g.memberIndices.length} passenger${g.memberIndices.length > 1 ? 's' : ''}`}
+                </span>
+              </div>
+              {colCount > 1 && (
+                <button type="button" onClick={() => removeGroup(g.id)} className="w-6 h-6 rounded-full bg-red-100 text-red-500 hover:bg-red-200 flex items-center justify-center text-[10px] transition-colors">✕</button>
+              )}
+            </div>
+
+            <div className="px-4 py-3 space-y-4">
+              {/* Members */}
+              <div>
+                <p className="text-[10px] font-semibold text-blue-400 uppercase tracking-wide mb-1.5">Members</p>
+                <div className="flex flex-wrap gap-1.5">
+                  {Array.from({ length: passengerCount }, (_, idx) => {
+                    const selected = g.memberIndices.includes(idx);
+                    return (
+                      <button key={idx} type="button" onClick={() => toggleMember(g.id, idx)}
+                        className={`px-2.5 py-1 rounded-lg text-xs font-semibold border transition-all ${selected ? 'bg-blue-600 border-blue-600 text-white' : 'bg-white border-blue-200 text-blue-500 hover:border-blue-400'}`}
+                      >{memberName(idx)}</button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Arrival */}
+              <div>
+                <p className="text-[10px] font-bold text-blue-400 uppercase tracking-widest mb-2 border-t border-blue-100 pt-3">Arrival</p>
+                <div className="grid grid-cols-2 gap-2 mb-2">
+                  <div>
+                    <FieldLabel>Date</FieldLabel>
+                    <TextInput value={g.arrivalDate ?? ''} onChange={v => updateGroup(g.id, { arrivalDate: v })} type="date" />
+                  </div>
+                  <div>
+                    <FieldLabel>Time</FieldLabel>
+                    <TextInput value={g.arrivalTime ?? ''} onChange={v => updateGroup(g.id, { arrivalTime: v })} type="time" />
+                  </div>
+                </div>
+                <div className="mb-2">
+                  <FieldLabel>Flight No.</FieldLabel>
+                  <TextInput value={g.arrivalFlight ?? ''} onChange={v => updateGroup(g.id, { arrivalFlight: v })} placeholder="e.g. EZY1234" />
+                </div>
+                <div className="mb-2">
+                  <FieldLabel>Hotel before boarding?</FieldLabel>
+                  <PillToggle options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
+                    value={g.stayingAtHotel ? 'yes' : g.stayingAtHotel === false ? 'no' : ''}
+                    onChange={v => updateGroup(g.id, { stayingAtHotel: v === 'yes' })} />
+                  {g.stayingAtHotel && (
+                    <div className="mt-1.5">
+                      <TextInput value={g.hotelName ?? ''} onChange={v => updateGroup(g.id, { hotelName: v })} placeholder="Hotel name & contact" />
+                    </div>
+                  )}
+                </div>
+                <div>
+                  <FieldLabel>Transfer to marina?</FieldLabel>
+                  <PillToggle options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
+                    value={g.transferFromAirport ? 'yes' : g.transferFromAirport === false ? 'no' : ''}
+                    onChange={v => updateGroup(g.id, { transferFromAirport: v === 'yes' })} />
+                </div>
+              </div>
+
+              {/* Departure */}
+              <div>
+                <p className="text-[10px] font-bold text-blue-400 uppercase tracking-widest mb-2 border-t border-blue-100 pt-3">Departure</p>
+                <div className="grid grid-cols-2 gap-2 mb-2">
+                  <div>
+                    <FieldLabel>Date</FieldLabel>
+                    <TextInput value={g.departureDate ?? ''} onChange={v => updateGroup(g.id, { departureDate: v })} type="date" />
+                  </div>
+                  <div>
+                    <FieldLabel>Time</FieldLabel>
+                    <TextInput value={g.departureTime ?? ''} onChange={v => updateGroup(g.id, { departureTime: v })} type="time" />
+                  </div>
+                </div>
+                <div className="mb-2">
+                  <FieldLabel>Flight No.</FieldLabel>
+                  <TextInput value={g.departureFlight ?? ''} onChange={v => updateGroup(g.id, { departureFlight: v })} placeholder="e.g. BA456" />
+                </div>
+                <div>
+                  <FieldLabel>Transfer to airport?</FieldLabel>
+                  <PillToggle options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
+                    value={g.transferToAirport ? 'yes' : g.transferToAirport === false ? 'no' : ''}
+                    onChange={v => updateGroup(g.id, { transferToAirport: v === 'yes' })} />
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* ── Desktop: side-by-side table (md+) ── */}
+      <div className="hidden md:block bg-white/80 backdrop-blur-sm border border-blue-100 rounded-xl shadow-sm overflow-x-auto">
         <table className="w-full min-w-[480px]">
           <thead>
             <tr className="border-b border-blue-100">
@@ -630,20 +729,13 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
                   <div className="flex items-center justify-between gap-2">
                     <span className="text-sm font-bold text-blue-900">Group {gi + 1}</span>
                     {colCount > 1 && (
-                      <button
-                        type="button"
-                        onClick={() => removeGroup(g.id)}
+                      <button type="button" onClick={() => removeGroup(g.id)}
                         className="w-5 h-5 rounded-full bg-red-100 text-red-500 hover:bg-red-200 flex items-center justify-center text-[10px] transition-colors flex-shrink-0"
-                        title="Remove group"
-                      >✕</button>
+                        title="Remove group">✕</button>
                     )}
                   </div>
                   <p className="text-[10px] text-blue-400 mt-0.5">
-                    {g.memberIndices.length === 0
-                      ? 'No members assigned'
-                      : g.memberIndices.length === passengerCount
-                      ? 'All passengers'
-                      : `${g.memberIndices.length} passenger${g.memberIndices.length > 1 ? 's' : ''}`}
+                    {g.memberIndices.length === 0 ? 'No members assigned' : g.memberIndices.length === passengerCount ? 'All passengers' : `${g.memberIndices.length} passenger${g.memberIndices.length > 1 ? 's' : ''}`}
                   </p>
                 </th>
               ))}
@@ -651,7 +743,6 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
           </thead>
           <tbody className="px-4">
 
-            {/* Members row */}
             <TableRow label="Members">
               {groups.map(g => (
                 <td key={g.id} className="py-1.5 px-2 align-top">
@@ -659,18 +750,9 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
                     {Array.from({ length: passengerCount }, (_, idx) => {
                       const selected = g.memberIndices.includes(idx);
                       return (
-                        <button
-                          key={idx}
-                          type="button"
-                          onClick={() => toggleMember(g.id, idx)}
-                          className={`px-2 py-1 rounded-lg text-[11px] font-semibold border transition-all ${
-                            selected
-                              ? 'bg-blue-600 border-blue-600 text-white'
-                              : 'bg-white border-blue-200 text-blue-500 hover:border-blue-400'
-                          }`}
-                        >
-                          {memberName(idx)}
-                        </button>
+                        <button key={idx} type="button" onClick={() => toggleMember(g.id, idx)}
+                          className={`px-2 py-1 rounded-lg text-[11px] font-semibold border transition-all ${selected ? 'bg-blue-600 border-blue-600 text-white' : 'bg-white border-blue-200 text-blue-500 hover:border-blue-400'}`}
+                        >{memberName(idx)}</button>
                       );
                     })}
                   </div>
@@ -678,7 +760,6 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
               ))}
             </TableRow>
 
-            {/* ── ARRIVAL ── */}
             <tr className="border-t-2 border-blue-200">
               <td colSpan={colCount + 1} className="py-2 px-0">
                 <span className="text-[10px] font-bold text-blue-400 uppercase tracking-widest">Arrival</span>
@@ -712,11 +793,9 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
             <TableRow label="Hotel before boarding?">
               {groups.map(g => (
                 <td key={g.id} className="py-2 px-3 align-top space-y-2">
-                  <PillToggle
-                    options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
+                  <PillToggle options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
                     value={g.stayingAtHotel ? 'yes' : g.stayingAtHotel === false ? 'no' : ''}
-                    onChange={v => updateGroup(g.id, { stayingAtHotel: v === 'yes' })}
-                  />
+                    onChange={v => updateGroup(g.id, { stayingAtHotel: v === 'yes' })} />
                   {g.stayingAtHotel && (
                     <TextInput value={g.hotelName ?? ''} onChange={v => updateGroup(g.id, { hotelName: v })} placeholder="Hotel name & contact" />
                   )}
@@ -727,16 +806,13 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
             <TableRow label="Transfer to marina?">
               {groups.map(g => (
                 <td key={g.id} className="py-1.5 px-2 align-top">
-                  <PillToggle
-                    options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
+                  <PillToggle options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
                     value={g.transferFromAirport ? 'yes' : g.transferFromAirport === false ? 'no' : ''}
-                    onChange={v => updateGroup(g.id, { transferFromAirport: v === 'yes' })}
-                  />
+                    onChange={v => updateGroup(g.id, { transferFromAirport: v === 'yes' })} />
                 </td>
               ))}
             </TableRow>
 
-            {/* ── DEPARTURE ── */}
             <tr className="border-t-2 border-blue-200">
               <td colSpan={colCount + 1} className="py-2 px-0">
                 <span className="text-[10px] font-bold text-blue-400 uppercase tracking-widest">Departure</span>
@@ -770,11 +846,9 @@ function TravelStep({ initial, crew, onSave, onAutoSave }: {
             <TableRow label="Transfer to airport?">
               {groups.map(g => (
                 <td key={g.id} className="py-1.5 px-2 align-top">
-                  <PillToggle
-                    options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
+                  <PillToggle options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
                     value={g.transferToAirport ? 'yes' : g.transferToAirport === false ? 'no' : ''}
-                    onChange={v => updateGroup(g.id, { transferToAirport: v === 'yes' })}
-                  />
+                    onChange={v => updateGroup(g.id, { transferToAirport: v === 'yes' })} />
                 </td>
               ))}
             </TableRow>

--- a/app/client-space/[token]/ClientSpaceClient.tsx
+++ b/app/client-space/[token]/ClientSpaceClient.tsx
@@ -1,0 +1,1221 @@
+'use client';
+
+import { useEffect, useState, useRef, useCallback, type ReactNode } from 'react';
+import Image from 'next/image';
+import {
+  getClientPreparation,
+  getCharterByClientSpaceToken,
+  saveCrew,
+  saveTravel,
+  saveActivities,
+  saveFood,
+  saveBeverages,
+  saveSpecial,
+  saveChecklist,
+  saveStep,
+  CHECKLIST_CATEGORIES,
+  type ClientPreparation,
+  type CrewMember,
+  type TravelLogistics,
+  type ActivityPreferences,
+  type FoodPreferences,
+  type BeveragePreferences,
+  type SpecialRequests,
+} from '../../../lib/clientSpace';
+import type { Charter } from '../../../lib/availability';
+import { getMarinaById } from '../../marinas-data';
+import { CONTACT } from '../../config/contact';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fmtDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+
+function nightCount(start: string, end: string) {
+  return Math.round((new Date(end).getTime() - new Date(start).getTime()) / 86400000);
+}
+
+const STEPS = [
+  'Your Charter',
+  'Crew Details',
+  'Travel & Logistics',
+  'Activities & Health',
+  'Food Preferences',
+  'Beverages & Bar',
+  'Special Requests',
+];
+
+const GENDERS = ['Male', 'Female', 'Other', 'Prefer not to say'];
+
+const NATIONALITIES = [
+  'American', 'Australian', 'Austrian', 'Belgian', 'Brazilian', 'British', 'Canadian',
+  'Chinese', 'Danish', 'Dutch', 'Finnish', 'French', 'German', 'Greek', 'Irish',
+  'Israeli', 'Italian', 'Japanese', 'Norwegian', 'Polish', 'Portuguese', 'Russian',
+  'South African', 'Spanish', 'Swedish', 'Swiss', 'Turkish', 'Other',
+];
+
+const ACTIVITY_OPTIONS = [
+  'Sailing', 'Swimming', 'Snorkelling', 'Fishing', 'Water Skiing', 'Kayaking',
+  'Island Hiking', 'Local Cuisine Tour', 'Sun Bathing', 'Beach Combing',
+  'Yoga on Deck', 'Star Gazing', 'Shopping', 'Nightlife', 'Scuba Diving',
+  'Paddleboarding', 'Windsurfing',
+];
+
+const WARM_BEVERAGES = [
+  'Espresso', 'Cappuccino', 'Filter Coffee', 'Hot Chocolate',
+  'Green Tea', 'Black Tea', 'Chamomile / Mint Infusions', 'Decaf Coffee',
+];
+
+const BREAKFAST_STYLES = [
+  { id: 'light', label: 'Light / Cold' },
+  { id: 'american', label: 'American (pancakes, muffins)' },
+  { id: 'full', label: 'Full Cooked (eggs, bacon, sausage)' },
+];
+
+const BREAKFAST_ITEMS = [
+  'Eggs', 'Bacon', 'Yoghurt', 'Fruits', 'Cereals', 'Cold Cuts',
+  'Honey', 'Jam', 'Soy / Almond Milk', 'Vegetables', 'Butter', 'Bread',
+];
+
+const MEAL_STYLES = ['Light', 'Heavy', 'Hot'];
+
+const SODA_TYPES = [
+  'Coke 0.5 l', 'Diet Coke 0.5 l', 'Sprite 0.5 l', 'Pepsi 0.5 l',
+  'Orange Juice 1.0 l', 'Apple Juice 1.0 l', 'Cranberry Juice 1.0 l',
+  'Tonic Water 1.5 l', 'Water Still 0.5 l', 'Water Sparkling 0.5 l',
+];
+
+const WINE_TYPES = ['White Wine', 'Red Wine', 'Rosé Wine', 'Champagne / Sparkling'];
+
+const SPIRIT_TYPES = [
+  'Vodka', 'Gin', 'Rum', 'Whisky / Scotch', 'Tequila',
+  'Beer (local)', 'Beer (imported)', 'Liqueurs',
+];
+
+const FOOD_CATEGORIES = ['Seafood', 'Meat', 'Fruit', 'Vegetables', 'Dairy', 'Other'] as const;
+
+// ---------------------------------------------------------------------------
+// Toast
+// ---------------------------------------------------------------------------
+
+function Toast({ msg, onDone }: { msg: string; onDone: () => void }) {
+  useEffect(() => {
+    const t = setTimeout(onDone, 3000);
+    return () => clearTimeout(t);
+  }, [onDone]);
+  return (
+    <div className="fixed bottom-6 right-6 z-50 px-5 py-3 bg-emerald-600 text-white text-sm rounded-xl shadow-xl animate-fade-in-up">
+      {msg}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reusable field components
+// ---------------------------------------------------------------------------
+
+function FieldLabel({ children }: { children: ReactNode }) {
+  return <label className="block text-sm font-medium text-blue-900 mb-1">{children}</label>;
+}
+
+function TextInput({ value, onChange, placeholder, type = 'text' }: {
+  value: string; onChange: (v: string) => void; placeholder?: string; type?: string;
+}) {
+  return (
+    <input
+      type={type}
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      placeholder={placeholder}
+      className="w-full border-2 border-blue-100 rounded-xl px-3 py-2 text-sm text-blue-900 focus:outline-none focus:border-blue-400 bg-white/80"
+    />
+  );
+}
+
+function TextArea({ value, onChange, placeholder, rows = 3 }: {
+  value: string; onChange: (v: string) => void; placeholder?: string; rows?: number;
+}) {
+  return (
+    <textarea
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      placeholder={placeholder}
+      rows={rows}
+      className="w-full border-2 border-blue-100 rounded-xl px-3 py-2 text-sm text-blue-900 focus:outline-none focus:border-blue-400 bg-white/80 resize-none"
+    />
+  );
+}
+
+function SelectInput({ value, onChange, options, placeholder }: {
+  value: string; onChange: (v: string) => void; options: string[]; placeholder?: string;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      className="w-full border-2 border-blue-100 rounded-xl px-3 py-2 text-sm text-blue-900 focus:outline-none focus:border-blue-400 bg-white/80"
+    >
+      {placeholder && <option value="">{placeholder}</option>}
+      {options.map(o => <option key={o} value={o}>{o}</option>)}
+    </select>
+  );
+}
+
+function PillToggle({ options, value, onChange }: {
+  options: { id: string; label: string }[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map(o => (
+        <button
+          key={o.id}
+          type="button"
+          onClick={() => onChange(value === o.id ? '' : o.id)}
+          className={`px-4 py-2 rounded-full text-sm font-medium transition-all border-2 ${
+            value === o.id
+              ? 'bg-blue-600 border-blue-600 text-white'
+              : 'bg-white border-blue-200 text-blue-700 hover:border-blue-400'
+          }`}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function MultiChip({ options, values, onChange }: {
+  options: string[];
+  values: string[];
+  onChange: (v: string[]) => void;
+}) {
+  function toggle(opt: string) {
+    onChange(values.includes(opt) ? values.filter(v => v !== opt) : [...values, opt]);
+  }
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map(o => (
+        <button
+          key={o}
+          type="button"
+          onClick={() => toggle(o)}
+          className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all border-2 ${
+            values.includes(o)
+              ? 'bg-blue-600 border-blue-600 text-white'
+              : 'bg-white border-blue-200 text-blue-600 hover:border-blue-400'
+          }`}
+        >
+          {o}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function SectionCard({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="bg-white/70 backdrop-blur-sm border border-blue-100 rounded-2xl p-5 space-y-4">
+      <h3 className="text-base font-bold text-blue-900">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function SaveButton({ onClick, saving, label = 'Save & Continue' }: {
+  onClick: () => void; saving: boolean; label?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={saving}
+      className="btn-primary px-8 py-3 text-sm font-semibold disabled:opacity-60 disabled:cursor-not-allowed"
+    >
+      {saving ? 'Saving…' : label}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step indicator
+// ---------------------------------------------------------------------------
+
+function StepIndicator({ current }: { current: number }) {
+  return (
+    <div className="flex items-center gap-1 overflow-x-auto pb-1">
+      {STEPS.map((label, i) => (
+        <div key={i} className="flex items-center flex-shrink-0">
+          <div className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
+            i === current
+              ? 'bg-white text-blue-700 shadow-sm font-semibold'
+              : i < current
+              ? 'bg-white/30 text-white'
+              : 'bg-white/10 text-blue-200'
+          }`}>
+            <span className={`w-4 h-4 rounded-full flex items-center justify-center text-[10px] font-bold flex-shrink-0 ${
+              i < current ? 'bg-emerald-400 text-white' : i === current ? 'bg-blue-600 text-white' : 'bg-white/20 text-blue-300'
+            }`}>
+              {i < current ? '✓' : i + 1}
+            </span>
+            <span className="hidden sm:inline">{label}</span>
+          </div>
+          {i < STEPS.length - 1 && (
+            <div className={`w-4 h-px mx-0.5 ${i < current ? 'bg-emerald-400/60' : 'bg-white/20'}`} />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 0: Charter overview
+// ---------------------------------------------------------------------------
+
+function BookingOverview({ charter }: { charter: Charter }) {
+  const delivery = getMarinaById(charter.deliveryPoint ?? '');
+  const redelivery = getMarinaById(charter.redeliveryPoint ?? charter.deliveryPoint ?? '');
+  const nights = charter.startDate && charter.endDate ? nightCount(charter.startDate, charter.endDate) : null;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {[
+          { label: 'Charter Start', value: charter.startDate ? fmtDate(charter.startDate) : '—' },
+          { label: 'Charter End', value: charter.endDate ? `${fmtDate(charter.endDate)}${nights ? ` (${nights} nights)` : ''}` : '—' },
+          { label: 'Vessel', value: charter.boat ?? 'BlueOne — Fountaine Pajot Aura 51' },
+          { label: 'Guests', value: charter.passengers ? `${charter.passengers} passenger${charter.passengers > 1 ? 's' : ''}` : '—' },
+          { label: 'Embarkation', value: delivery?.name ?? charter.embarkationPoint ?? '—' },
+          { label: 'Disembarkation', value: redelivery?.name ?? delivery?.name ?? '—' },
+          ...(charter.selectedTheme ? [{ label: 'Experience Theme', value: charter.selectedTheme }] : []),
+        ].map(({ label, value }) => (
+          <div key={label} className="bg-white/60 rounded-xl px-4 py-3">
+            <p className="text-xs font-semibold text-blue-400 uppercase tracking-wide mb-0.5">{label}</p>
+            <p className="text-sm font-medium text-blue-900">{value}</p>
+          </div>
+        ))}
+      </div>
+      {charter.holidayDescription && (
+        <div className="bg-blue-50/60 rounded-xl px-4 py-3">
+          <p className="text-xs font-semibold text-blue-400 uppercase tracking-wide mb-1">Your Holiday Vision</p>
+          <p className="text-sm text-blue-800 italic">&ldquo;{charter.holidayDescription}&rdquo;</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: Crew
+// ---------------------------------------------------------------------------
+
+function CrewStep({ count, initial, onSave }: {
+  count: number;
+  initial: CrewMember[];
+  onSave: (crew: CrewMember[]) => Promise<void>;
+}) {
+  const empty = (): CrewMember => ({
+    firstName: '', lastName: '', gender: '', dateOfBirth: '',
+    nationality: '', passportNumber: '', dietaryRestrictions: '', medicalNotes: '',
+  });
+
+  const [crew, setCrew] = useState<CrewMember[]>(() => {
+    const base = Array.from({ length: count }, (_, i) => initial[i] ?? empty());
+    return base;
+  });
+  const [saving, setSaving] = useState(false);
+  const [expanded, setExpanded] = useState(0);
+
+  function update(i: number, field: keyof CrewMember, val: string) {
+    setCrew(prev => prev.map((m, idx) => idx === i ? { ...m, [field]: val } : m));
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    try { await onSave(crew); } finally { setSaving(false); }
+  }
+
+  return (
+    <div className="space-y-4">
+      {crew.map((m, i) => (
+        <div key={i} className="bg-white/70 border border-blue-100 rounded-2xl overflow-hidden">
+          <button
+            type="button"
+            onClick={() => setExpanded(expanded === i ? -1 : i)}
+            className="w-full flex items-center justify-between px-5 py-4 text-left"
+          >
+            <div>
+              <span className="text-xs font-semibold text-blue-400 uppercase tracking-wide">
+                Passenger {i + 1}
+              </span>
+              <p className="text-sm font-semibold text-blue-900 mt-0.5">
+                {m.firstName || m.lastName ? `${m.firstName} ${m.lastName}`.trim() : 'Fill in details below'}
+              </p>
+            </div>
+            <svg
+              className={`w-5 h-5 text-blue-400 transition-transform ${expanded === i ? 'rotate-180' : ''}`}
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+
+          {expanded === i && (
+            <div className="px-5 pb-5 space-y-4 border-t border-blue-100">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-4">
+                <div>
+                  <FieldLabel>First Name</FieldLabel>
+                  <TextInput value={m.firstName} onChange={v => update(i, 'firstName', v)} placeholder="First name" />
+                </div>
+                <div>
+                  <FieldLabel>Last Name</FieldLabel>
+                  <TextInput value={m.lastName} onChange={v => update(i, 'lastName', v)} placeholder="Last name" />
+                </div>
+                <div>
+                  <FieldLabel>Gender</FieldLabel>
+                  <SelectInput value={m.gender ?? ''} onChange={v => update(i, 'gender', v)} options={GENDERS} placeholder="Select…" />
+                </div>
+                <div>
+                  <FieldLabel>Date of Birth</FieldLabel>
+                  <TextInput value={m.dateOfBirth ?? ''} onChange={v => update(i, 'dateOfBirth', v)} type="date" />
+                </div>
+                <div>
+                  <FieldLabel>Nationality</FieldLabel>
+                  <SelectInput value={m.nationality ?? ''} onChange={v => update(i, 'nationality', v)} options={NATIONALITIES} placeholder="Select…" />
+                </div>
+                <div>
+                  <FieldLabel>Passport Number</FieldLabel>
+                  <TextInput value={m.passportNumber ?? ''} onChange={v => update(i, 'passportNumber', v)} placeholder="Optional" />
+                </div>
+              </div>
+              <div>
+                <FieldLabel>Dietary Restrictions</FieldLabel>
+                <TextArea
+                  value={m.dietaryRestrictions ?? ''}
+                  onChange={v => update(i, 'dietaryRestrictions', v)}
+                  placeholder="Vegetarian, gluten-free, nut allergy…"
+                  rows={2}
+                />
+              </div>
+              <div>
+                <FieldLabel>Medical Notes</FieldLabel>
+                <TextArea
+                  value={m.medicalNotes ?? ''}
+                  onChange={v => update(i, 'medicalNotes', v)}
+                  placeholder="Any conditions the crew should be aware of (confidential)"
+                  rows={2}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      ))}
+      <div className="flex justify-end">
+        <SaveButton onClick={handleSave} saving={saving} label="Save Crew Details" />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: Travel & Logistics
+// ---------------------------------------------------------------------------
+
+function TravelStep({ initial, onSave }: {
+  initial: TravelLogistics;
+  onSave: (travel: TravelLogistics) => Promise<void>;
+}) {
+  const [data, setData] = useState<TravelLogistics>(initial);
+  const [saving, setSaving] = useState(false);
+  function set<K extends keyof TravelLogistics>(k: K, v: TravelLogistics[K]) {
+    setData(prev => ({ ...prev, [k]: v }));
+  }
+  async function handleSave() { setSaving(true); try { await onSave(data); } finally { setSaving(false); } }
+
+  return (
+    <div className="space-y-4">
+      <SectionCard title="Arrival">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div>
+            <FieldLabel>Arrival Date</FieldLabel>
+            <TextInput value={data.arrivalDate ?? ''} onChange={v => set('arrivalDate', v)} type="date" />
+          </div>
+          <div>
+            <FieldLabel>Arrival Time</FieldLabel>
+            <TextInput value={data.arrivalTime ?? ''} onChange={v => set('arrivalTime', v)} type="time" />
+          </div>
+          <div>
+            <FieldLabel>Flight Number</FieldLabel>
+            <TextInput value={data.arrivalFlight ?? ''} onChange={v => set('arrivalFlight', v)} placeholder="e.g. EasyJet EZY1234" />
+          </div>
+        </div>
+        <div className="space-y-2">
+          <FieldLabel>Staying at a hotel before boarding?</FieldLabel>
+          <PillToggle
+            options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
+            value={data.stayingAtHotel ? 'yes' : data.stayingAtHotel === false ? 'no' : ''}
+            onChange={v => set('stayingAtHotel', v === 'yes')}
+          />
+          {data.stayingAtHotel && (
+            <div className="mt-2">
+              <FieldLabel>Hotel Name & Contact</FieldLabel>
+              <TextInput value={data.hotelName ?? ''} onChange={v => set('hotelName', v)} placeholder="Hotel name and phone/address" />
+            </div>
+          )}
+        </div>
+        <div className="space-y-2">
+          <FieldLabel>Airport transfer to marina needed?</FieldLabel>
+          <PillToggle
+            options={[{ id: 'yes', label: 'Yes — arrange please' }, { id: 'no', label: 'No — I\'ll arrange my own' }]}
+            value={data.transferFromAirport ? 'yes' : data.transferFromAirport === false ? 'no' : ''}
+            onChange={v => set('transferFromAirport', v === 'yes')}
+          />
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Departure">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div>
+            <FieldLabel>Departure Date</FieldLabel>
+            <TextInput value={data.departureDate ?? ''} onChange={v => set('departureDate', v)} type="date" />
+          </div>
+          <div>
+            <FieldLabel>Departure Time</FieldLabel>
+            <TextInput value={data.departureTime ?? ''} onChange={v => set('departureTime', v)} type="time" />
+          </div>
+          <div>
+            <FieldLabel>Flight Number</FieldLabel>
+            <TextInput value={data.departureFlight ?? ''} onChange={v => set('departureFlight', v)} placeholder="e.g. BA456" />
+          </div>
+        </div>
+        <div className="space-y-2">
+          <FieldLabel>Airport transfer from marina needed?</FieldLabel>
+          <PillToggle
+            options={[{ id: 'yes', label: 'Yes — arrange please' }, { id: 'no', label: 'No — I\'ll arrange my own' }]}
+            value={data.transferToAirport ? 'yes' : data.transferToAirport === false ? 'no' : ''}
+            onChange={v => set('transferToAirport', v === 'yes')}
+          />
+        </div>
+      </SectionCard>
+
+      <div className="flex justify-end">
+        <SaveButton onClick={handleSave} saving={saving} label="Save Travel Details" />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 3: Activities & Health
+// ---------------------------------------------------------------------------
+
+function ActivitiesStep({ initial, onSave }: {
+  initial: ActivityPreferences;
+  onSave: (data: ActivityPreferences) => Promise<void>;
+}) {
+  const [data, setData] = useState<ActivityPreferences>(initial);
+  const [saving, setSaving] = useState(false);
+  function set<K extends keyof ActivityPreferences>(k: K, v: ActivityPreferences[K]) {
+    setData(prev => ({ ...prev, [k]: v }));
+  }
+  async function handleSave() { setSaving(true); try { await onSave(data); } finally { setSaving(false); } }
+
+  return (
+    <div className="space-y-4">
+      <SectionCard title="Group Style">
+        <PillToggle
+          options={[
+            { id: 'active', label: 'Active & on the go' },
+            { id: 'relaxed', label: 'Relaxed & laid-back' },
+            { id: 'combination', label: 'A bit of both' },
+          ]}
+          value={data.groupStyle ?? ''}
+          onChange={v => set('groupStyle', v as ActivityPreferences['groupStyle'])}
+        />
+      </SectionCard>
+
+      <SectionCard title="Activities">
+        <p className="text-xs text-blue-500">Select all that interest your group</p>
+        <MultiChip
+          options={ACTIVITY_OPTIONS}
+          values={data.activities ?? []}
+          onChange={v => set('activities', v)}
+        />
+        <div>
+          <FieldLabel>Specific places or anchorages you&apos;d love to visit</FieldLabel>
+          <TextInput
+            value={data.specificPlaces ?? ''}
+            onChange={v => set('specificPlaces', v)}
+            placeholder="e.g. Santorini caldera, Blue Caves Zakynthos…"
+          />
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Health & Experience">
+        <div>
+          <FieldLabel>Medical Information</FieldLabel>
+          <TextArea
+            value={data.healthNotes ?? ''}
+            onChange={v => set('healthNotes', v)}
+            placeholder="Heart conditions, severe allergies, mobility considerations — anything the crew should know (confidential)"
+            rows={4}
+          />
+        </div>
+        <div>
+          <FieldLabel>Sailing & Chartering Experience</FieldLabel>
+          <TextArea
+            value={data.sailingExperience ?? ''}
+            onChange={v => set('sailingExperience', v)}
+            placeholder="Briefly describe your group's sailing background — helps us calibrate the pace"
+            rows={3}
+          />
+        </div>
+      </SectionCard>
+
+      <div className="flex justify-end">
+        <SaveButton onClick={handleSave} saving={saving} label="Save Activities & Health" />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 4: Food preferences
+// ---------------------------------------------------------------------------
+
+function FoodStep({ initial, onSave }: {
+  initial: FoodPreferences;
+  onSave: (food: FoodPreferences) => Promise<void>;
+}) {
+  const [data, setData] = useState<FoodPreferences>(initial);
+  const [saving, setSaving] = useState(false);
+
+  function setCategory(cat: string, field: 'likes' | 'dislikes' | 'allergies', val: string) {
+    setData(prev => ({
+      ...prev,
+      [cat]: { ...(prev[cat as keyof FoodPreferences] as object ?? {}), [field]: val },
+    }));
+  }
+
+  function set<K extends keyof FoodPreferences>(k: K, v: FoodPreferences[K]) {
+    setData(prev => ({ ...prev, [k]: v }));
+  }
+
+  function toggleBreakfastStyle(id: string) {
+    const current = data.breakfastStyle ?? [];
+    set('breakfastStyle', current.includes(id) ? current.filter(x => x !== id) : [...current, id]);
+  }
+
+  function toggleBreakfastItem(item: string) {
+    const current = data.breakfastItems ?? [];
+    set('breakfastItems', current.includes(item) ? current.filter(x => x !== item) : [...current, item]);
+  }
+
+  async function handleSave() { setSaving(true); try { await onSave(data); } finally { setSaving(false); } }
+
+  type CatKey = Lowercase<typeof FOOD_CATEGORIES[number]>;
+
+  return (
+    <div className="space-y-4">
+      <SectionCard title="Food Preferences by Category">
+        <p className="text-xs text-blue-500">Help us plan menus tailored to your group</p>
+        <div className="space-y-4">
+          {FOOD_CATEGORIES.map(cat => {
+            const key = cat.toLowerCase() as CatKey;
+            const catData = (data[key as keyof FoodPreferences] as { likes?: string; dislikes?: string; allergies?: string }) ?? {};
+            return (
+              <div key={cat} className="border border-blue-100 rounded-xl p-4 space-y-3">
+                <p className="text-sm font-semibold text-blue-800">{cat}</p>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                  <div>
+                    <FieldLabel>Likes</FieldLabel>
+                    <TextInput value={catData.likes ?? ''} onChange={v => setCategory(key, 'likes', v)} placeholder="e.g. grilled fish" />
+                  </div>
+                  <div>
+                    <FieldLabel>Dislikes</FieldLabel>
+                    <TextInput value={catData.dislikes ?? ''} onChange={v => setCategory(key, 'dislikes', v)} placeholder="e.g. anchovies" />
+                  </div>
+                  <div>
+                    <FieldLabel>Allergies / Comments</FieldLabel>
+                    <TextInput value={catData.allergies ?? ''} onChange={v => setCategory(key, 'allergies', v)} placeholder="e.g. shellfish allergy" />
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Breakfast">
+        <div>
+          <FieldLabel>Preferred style (select all that apply)</FieldLabel>
+          <div className="flex flex-wrap gap-2 mt-1">
+            {BREAKFAST_STYLES.map(s => (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => toggleBreakfastStyle(s.id)}
+                className={`px-4 py-2 rounded-full text-sm font-medium transition-all border-2 ${
+                  (data.breakfastStyle ?? []).includes(s.id)
+                    ? 'bg-blue-600 border-blue-600 text-white'
+                    : 'bg-white border-blue-200 text-blue-700 hover:border-blue-400'
+                }`}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div>
+          <FieldLabel>Breakfast items</FieldLabel>
+          <div className="flex flex-wrap gap-2 mt-1">
+            {BREAKFAST_ITEMS.map(item => (
+              <button
+                key={item}
+                type="button"
+                onClick={() => toggleBreakfastItem(item)}
+                className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all border-2 ${
+                  (data.breakfastItems ?? []).includes(item)
+                    ? 'bg-blue-600 border-blue-600 text-white'
+                    : 'bg-white border-blue-200 text-blue-600 hover:border-blue-400'
+                }`}
+              >
+                {item}
+              </button>
+            ))}
+          </div>
+        </div>
+      </SectionCard>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <SectionCard title="Lunch">
+          <div>
+            <FieldLabel>Style</FieldLabel>
+            <PillToggle
+              options={MEAL_STYLES.map(s => ({ id: s.toLowerCase(), label: s }))}
+              value={data.lunchStyle ?? ''}
+              onChange={v => set('lunchStyle', v)}
+            />
+          </div>
+          <div>
+            <FieldLabel>Dessert?</FieldLabel>
+            <PillToggle
+              options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
+              value={data.lunchDessert === true ? 'yes' : data.lunchDessert === false ? 'no' : ''}
+              onChange={v => set('lunchDessert', v === 'yes')}
+            />
+          </div>
+          <div>
+            <FieldLabel>Snacks / Hors d&apos;œuvres</FieldLabel>
+            <TextInput value={data.lunchSnacks ?? ''} onChange={v => set('lunchSnacks', v)} placeholder="Cheese, crudités…" />
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Dinner">
+          <div>
+            <FieldLabel>Style</FieldLabel>
+            <PillToggle
+              options={MEAL_STYLES.map(s => ({ id: s.toLowerCase(), label: s }))}
+              value={data.dinnerStyle ?? ''}
+              onChange={v => set('dinnerStyle', v)}
+            />
+          </div>
+          <div>
+            <FieldLabel>Dessert?</FieldLabel>
+            <PillToggle
+              options={[{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }]}
+              value={data.dinnerDessert === true ? 'yes' : data.dinnerDessert === false ? 'no' : ''}
+              onChange={v => set('dinnerDessert', v === 'yes')}
+            />
+          </div>
+        </SectionCard>
+      </div>
+
+      <div className="flex justify-end">
+        <SaveButton onClick={handleSave} saving={saving} label="Save Food Preferences" />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 5: Beverages
+// ---------------------------------------------------------------------------
+
+function BeverageRow({ label, item, onChange }: {
+  label: string;
+  item: { preferredBrand?: string; qty?: number; remarks?: string };
+  onChange: (v: { preferredBrand?: string; qty?: number; remarks?: string }) => void;
+}) {
+  return (
+    <div className="grid grid-cols-3 sm:grid-cols-[2fr_1fr_2fr] gap-2 items-center py-2 border-b border-blue-50 last:border-0">
+      <span className="text-xs font-medium text-blue-800">{label}</span>
+      <input
+        type="number"
+        min={0}
+        placeholder="Qty"
+        value={item.qty ?? ''}
+        onChange={e => onChange({ ...item, qty: e.target.value ? Number(e.target.value) : undefined })}
+        className="border border-blue-100 rounded-lg px-2 py-1.5 text-xs text-blue-900 focus:outline-none focus:border-blue-400 bg-white/80 w-full"
+      />
+      <input
+        type="text"
+        placeholder="Brand / remarks"
+        value={item.preferredBrand ?? ''}
+        onChange={e => onChange({ ...item, preferredBrand: e.target.value })}
+        className="border border-blue-100 rounded-lg px-2 py-1.5 text-xs text-blue-900 focus:outline-none focus:border-blue-400 bg-white/80 w-full"
+      />
+    </div>
+  );
+}
+
+function BeveragesStep({ initial, onSave }: {
+  initial: BeveragePreferences;
+  onSave: (bev: BeveragePreferences) => Promise<void>;
+}) {
+  const [data, setData] = useState<BeveragePreferences>(initial);
+  const [saving, setSaving] = useState(false);
+
+  function toggleWarm(item: string) {
+    const current = data.warmBeverages ?? [];
+    setData(prev => ({
+      ...prev,
+      warmBeverages: current.includes(item) ? current.filter(x => x !== item) : [...current, item],
+    }));
+  }
+
+  function updateRow(group: 'sodas' | 'wines' | 'spirits', key: string, val: { preferredBrand?: string; qty?: number; remarks?: string }) {
+    setData(prev => ({ ...prev, [group]: { ...(prev[group] ?? {}), [key]: val } }));
+  }
+
+  async function handleSave() { setSaving(true); try { await onSave(data); } finally { setSaving(false); } }
+
+  return (
+    <div className="space-y-4">
+      <SectionCard title="Hot Beverages">
+        <MultiChip
+          options={WARM_BEVERAGES}
+          values={data.warmBeverages ?? []}
+          onChange={v => setData(prev => ({ ...prev, warmBeverages: v }))}
+        />
+        <div>
+          <FieldLabel>Other (please specify)</FieldLabel>
+          <TextInput
+            value={data.warmBeveragesOther ?? ''}
+            onChange={v => setData(prev => ({ ...prev, warmBeveragesOther: v }))}
+            placeholder="Any other hot beverage preferences"
+          />
+        </div>
+      </SectionCard>
+
+      {([
+        { title: 'Sodas, Juices & Water', group: 'sodas' as const, types: SODA_TYPES },
+        { title: 'Wines & Sparkling', group: 'wines' as const, types: WINE_TYPES },
+        { title: 'Spirits & Beer', group: 'spirits' as const, types: SPIRIT_TYPES },
+      ]).map(({ title, group, types }) => (
+        <SectionCard key={group} title={title}>
+          <div className="grid grid-cols-3 sm:grid-cols-[2fr_1fr_2fr] gap-2 mb-1">
+            <span className="text-[10px] font-bold text-blue-400 uppercase tracking-wide">Item</span>
+            <span className="text-[10px] font-bold text-blue-400 uppercase tracking-wide">Qty</span>
+            <span className="text-[10px] font-bold text-blue-400 uppercase tracking-wide">Brand / Notes</span>
+          </div>
+          {types.map(t => (
+            <BeverageRow
+              key={t}
+              label={t}
+              item={(data[group] ?? {})[t] ?? {}}
+              onChange={v => updateRow(group, t, v)}
+            />
+          ))}
+        </SectionCard>
+      ))}
+
+      <div className="flex justify-end">
+        <SaveButton onClick={handleSave} saving={saving} label="Save Beverage Preferences" />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 6: Special requests + checklist
+// ---------------------------------------------------------------------------
+
+function SpecialStep({ initial, checklistInit, onSave, onChecklistChange }: {
+  initial: SpecialRequests;
+  checklistInit: Record<string, boolean>;
+  onSave: (data: SpecialRequests) => Promise<void>;
+  onChecklistChange: (checklist: Record<string, boolean>) => void;
+}) {
+  const [data, setData] = useState<SpecialRequests>(initial);
+  const [checklist, setChecklist] = useState<Record<string, boolean>>(checklistInit);
+  const [saving, setSaving] = useState(false);
+
+  function set<K extends keyof SpecialRequests>(k: K, v: SpecialRequests[K]) {
+    setData(prev => ({ ...prev, [k]: v }));
+  }
+
+  function toggleItem(id: string) {
+    const next = { ...checklist, [id]: !checklist[id] };
+    setChecklist(next);
+    onChecklistChange(next);
+  }
+
+  const totalItems = CHECKLIST_CATEGORIES.flatMap(c => c.items).length;
+  const checked = Object.values(checklist).filter(Boolean).length;
+
+  async function handleSave() { setSaving(true); try { await onSave(data); } finally { setSaving(false); } }
+
+  return (
+    <div className="space-y-4">
+      <SectionCard title="Special Requests">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <FieldLabel>Special Occasion</FieldLabel>
+            <TextInput
+              value={data.celebration ?? ''}
+              onChange={v => set('celebration', v)}
+              placeholder="Birthday, anniversary, honeymoon…"
+            />
+          </div>
+          <div>
+            <FieldLabel>Music Atmosphere</FieldLabel>
+            <TextInput
+              value={data.musicAtmosphere ?? ''}
+              onChange={v => set('musicAtmosphere', v)}
+              placeholder="Jazz, Mediterranean, silence preferred…"
+            />
+          </div>
+          <div>
+            <FieldLabel>Pets on Board?</FieldLabel>
+            <TextInput
+              value={data.petsOnBoard ?? ''}
+              onChange={v => set('petsOnBoard', v)}
+              placeholder="Type and breed, or 'None'"
+            />
+          </div>
+        </div>
+        <div>
+          <FieldLabel>Emergency Contact</FieldLabel>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <TextInput value={data.emergencyContactName ?? ''} onChange={v => set('emergencyContactName', v)} placeholder="Full name" />
+            <TextInput value={data.emergencyContactPhone ?? ''} onChange={v => set('emergencyContactPhone', v)} placeholder="Phone number" type="tel" />
+            <TextInput value={data.emergencyContactRelation ?? ''} onChange={v => set('emergencyContactRelation', v)} placeholder="Relationship" />
+          </div>
+        </div>
+        <div>
+          <FieldLabel>Any Other Requests for the Crew</FieldLabel>
+          <TextArea
+            value={data.extraNotes ?? ''}
+            onChange={v => set('extraNotes', v)}
+            placeholder="Anything else we should know to make your holiday perfect"
+            rows={4}
+          />
+        </div>
+      </SectionCard>
+
+      <div className="bg-white/70 border border-blue-100 rounded-2xl p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-base font-bold text-blue-900">Pre-Departure Checklist</h3>
+          <span className="text-sm font-semibold text-blue-600">{checked} / {totalItems}</span>
+        </div>
+        <div className="w-full bg-blue-100 rounded-full h-2">
+          <div
+            className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+            style={{ width: `${totalItems ? (checked / totalItems) * 100 : 0}%` }}
+          />
+        </div>
+        {CHECKLIST_CATEGORIES.map(cat => (
+          <div key={cat.id}>
+            <p className="text-xs font-bold text-blue-400 uppercase tracking-wide mb-2">{cat.label}</p>
+            <div className="space-y-1.5">
+              {cat.items.map(item => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => toggleItem(item.id)}
+                  className={`w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-left transition-all border ${
+                    checklist[item.id]
+                      ? 'bg-emerald-50 border-emerald-200'
+                      : 'bg-white border-blue-100 hover:border-blue-300'
+                  }`}
+                >
+                  <span className={`flex-shrink-0 w-5 h-5 rounded-full border-2 flex items-center justify-center text-xs font-bold transition-all ${
+                    checklist[item.id]
+                      ? 'border-emerald-500 bg-emerald-500 text-white'
+                      : 'border-blue-300'
+                  }`}>
+                    {checklist[item.id] ? '✓' : ''}
+                  </span>
+                  <span className={`text-sm ${checklist[item.id] ? 'text-emerald-700 line-through' : 'text-blue-800'}`}>
+                    {item.label}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex justify-end">
+        <SaveButton onClick={handleSave} saving={saving} label="Save & Complete" />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+interface Props { token: string }
+
+export default function ClientSpaceClient({ token }: Props) {
+  const [charter, setCharter] = useState<Charter | null>(null);
+  const [prep, setPrep] = useState<ClientPreparation | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [toast, setToast] = useState<string | null>(null);
+  const checklistRef = useRef<Record<string, boolean>>({});
+
+  useEffect(() => {
+    Promise.all([
+      getCharterByClientSpaceToken(token),
+      getClientPreparation(token),
+    ])
+      .then(([c, p]) => {
+        if (!c || !p) { setNotFound(true); return; }
+        setCharter(c);
+        setPrep(p);
+        checklistRef.current = p.checklist ?? {};
+        setCurrentStep(p.lastSavedStep ?? 0);
+      })
+      .catch(() => setNotFound(true))
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  const showToast = useCallback((msg: string) => setToast(msg), []);
+
+  async function handleSaveCrew(crew: CrewMember[]) {
+    await saveCrew(token, crew);
+    setPrep(prev => prev ? { ...prev, crew } : prev);
+    await saveStep(token, Math.max(currentStep, 1));
+    setCurrentStep(s => Math.max(s, 1));
+    showToast('Crew details saved ✓');
+  }
+
+  async function handleSaveTravel(travel: TravelLogistics) {
+    await saveTravel(token, travel);
+    setPrep(prev => prev ? { ...prev, travel } : prev);
+    await saveStep(token, Math.max(currentStep, 2));
+    setCurrentStep(s => Math.max(s, 2));
+    showToast('Travel details saved ✓');
+  }
+
+  async function handleSaveActivities(activities: ActivityPreferences) {
+    await saveActivities(token, activities);
+    setPrep(prev => prev ? { ...prev, activities } : prev);
+    await saveStep(token, Math.max(currentStep, 3));
+    setCurrentStep(s => Math.max(s, 3));
+    showToast('Activities & health saved ✓');
+  }
+
+  async function handleSaveFood(food: FoodPreferences) {
+    await saveFood(token, food);
+    setPrep(prev => prev ? { ...prev, food } : prev);
+    await saveStep(token, Math.max(currentStep, 4));
+    setCurrentStep(s => Math.max(s, 4));
+    showToast('Food preferences saved ✓');
+  }
+
+  async function handleSaveBeverages(beverages: BeveragePreferences) {
+    await saveBeverages(token, beverages);
+    setPrep(prev => prev ? { ...prev, beverages } : prev);
+    await saveStep(token, Math.max(currentStep, 5));
+    setCurrentStep(s => Math.max(s, 5));
+    showToast('Beverage preferences saved ✓');
+  }
+
+  async function handleSaveSpecial(special: SpecialRequests) {
+    await saveSpecial(token, special);
+    setPrep(prev => prev ? { ...prev, special } : prev);
+    await saveStep(token, 6);
+    setCurrentStep(6);
+    showToast('All details saved — thank you! ✓');
+  }
+
+  function handleChecklistChange(checklist: Record<string, boolean>) {
+    checklistRef.current = checklist;
+    saveChecklist(token, checklist).catch(console.error);
+  }
+
+  // Loading
+  if (loading) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center" style={{ background: 'linear-gradient(135deg, #003d7a 0%, #0066cc 100%)' }}>
+        <div className="animate-pulse flex flex-col items-center gap-4">
+          <div className="w-16 h-16 rounded-full bg-white/20" />
+          <p className="text-white/60 text-sm">Loading your holiday space…</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Not found
+  if (notFound) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center px-4" style={{ background: 'linear-gradient(135deg, #003d7a 0%, #0066cc 100%)' }}>
+        <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-2xl p-10 text-center max-w-md">
+          <p className="text-4xl mb-4">⛵</p>
+          <h1 className="text-white text-xl font-bold mb-2">Link Not Found</h1>
+          <p className="text-blue-200 text-sm mb-6">This preparation link may have expired or is incorrect. Please contact us for a new link.</p>
+          <a href={`mailto:${CONTACT.email}`} className="btn-primary text-sm px-6 py-2.5">
+            Contact BlueOne
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  if (!charter || !prep) return null;
+
+  const passengerCount = charter.passengers ?? 1;
+
+  return (
+    <div className="min-h-screen" style={{ background: 'linear-gradient(135deg, #003d7a 0%, #0066cc 100%)' }}>
+      {/* Header */}
+      <div className="sticky top-0 z-40 bg-[#003d7a]/90 backdrop-blur-md border-b border-white/10">
+        <div className="max-w-3xl mx-auto px-4 py-3">
+          <div className="flex items-center gap-3 mb-3">
+            <Image src="/images/boats/blueone/logo_blueone.png" alt="BlueOne" width={90} height={36} className="object-contain" unoptimized />
+            <div className="flex-1 min-w-0">
+              <p className="text-white text-sm font-semibold leading-tight">Holiday Preparation</p>
+              {charter.name && <p className="text-blue-300 text-xs truncate">Welcome, {charter.name}</p>}
+            </div>
+          </div>
+          <StepIndicator current={currentStep} />
+        </div>
+      </div>
+
+      <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+        {/* Step nav buttons */}
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {STEPS.map((label, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => setCurrentStep(i)}
+              className={`flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-medium transition-all border ${
+                i === currentStep
+                  ? 'bg-white text-blue-700 border-white font-semibold'
+                  : i <= (prep.lastSavedStep ?? 0)
+                  ? 'bg-white/20 text-white border-white/30 hover:bg-white/30'
+                  : 'bg-white/10 text-blue-300 border-white/10 hover:bg-white/15'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {/* Section title */}
+        <div>
+          <h2 className="text-white text-2xl font-bold">{STEPS[currentStep]}</h2>
+          {currentStep === 0 && charter.name && (
+            <p className="text-blue-200 text-sm mt-1">
+              Welcome aboard, {charter.name}. Let&apos;s prepare your perfect sailing holiday.
+            </p>
+          )}
+        </div>
+
+        {/* Step content */}
+        {currentStep === 0 && (
+          <div className="space-y-4">
+            <BookingOverview charter={charter} />
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={() => setCurrentStep(1)}
+                className="btn-primary px-8 py-3 text-sm font-semibold"
+              >
+                Let&apos;s Get Started →
+              </button>
+            </div>
+          </div>
+        )}
+
+        {currentStep === 1 && (
+          <CrewStep count={passengerCount} initial={prep.crew} onSave={handleSaveCrew} />
+        )}
+
+        {currentStep === 2 && (
+          <TravelStep initial={prep.travel} onSave={handleSaveTravel} />
+        )}
+
+        {currentStep === 3 && (
+          <ActivitiesStep initial={prep.activities} onSave={handleSaveActivities} />
+        )}
+
+        {currentStep === 4 && (
+          <FoodStep initial={prep.food} onSave={handleSaveFood} />
+        )}
+
+        {currentStep === 5 && (
+          <BeveragesStep initial={prep.beverages} onSave={handleSaveBeverages} />
+        )}
+
+        {currentStep === 6 && (
+          <SpecialStep
+            initial={prep.special}
+            checklistInit={prep.checklist ?? {}}
+            onSave={handleSaveSpecial}
+            onChecklistChange={handleChecklistChange}
+          />
+        )}
+
+        {/* Prev / Next navigation */}
+        {currentStep > 0 && (
+          <div className="flex justify-between pt-4 border-t border-white/10">
+            <button
+              type="button"
+              onClick={() => setCurrentStep(s => s - 1)}
+              className="px-5 py-2.5 rounded-xl text-sm font-medium bg-white/10 hover:bg-white/20 text-white transition-colors border border-white/20"
+            >
+              ← Previous
+            </button>
+            {currentStep < STEPS.length - 1 && (
+              <button
+                type="button"
+                onClick={() => setCurrentStep(s => s + 1)}
+                className="px-5 py-2.5 rounded-xl text-sm font-medium bg-white/10 hover:bg-white/20 text-white transition-colors border border-white/20"
+              >
+                Next →
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Completion banner */}
+        {currentStep === 6 && (prep.lastSavedStep ?? 0) >= 6 && (
+          <div className="bg-emerald-500/20 border border-emerald-400/40 rounded-2xl p-6 text-center">
+            <p className="text-3xl mb-2">⛵</p>
+            <h3 className="text-white text-lg font-bold mb-1">All Set!</h3>
+            <p className="text-emerald-200 text-sm">Your preparation is complete. The BlueOne team has everything they need to plan your perfect holiday.</p>
+            <p className="text-emerald-300 text-xs mt-3">Questions? Contact us at <a href={`mailto:${CONTACT.email}`} className="underline">{CONTACT.email}</a></p>
+          </div>
+        )}
+
+        <div className="text-center pb-8">
+          <p className="text-blue-400 text-xs">Your progress is saved automatically after each section.</p>
+        </div>
+      </div>
+
+      {toast && <Toast msg={toast} onDone={() => setToast(null)} />}
+    </div>
+  );
+}

--- a/app/client-space/[token]/page.tsx
+++ b/app/client-space/[token]/page.tsx
@@ -1,0 +1,17 @@
+import { type Metadata } from 'next';
+import ClientSpaceClient from './ClientSpaceClient';
+
+export const metadata: Metadata = {
+  title: 'Holiday Preparation | BlueOne Luxury Yacht Charters',
+  description: 'Prepare for your upcoming sailing holiday.',
+  robots: { index: false, follow: false },
+};
+
+interface Props {
+  params: Promise<{ token: string }>;
+}
+
+export default async function ClientSpacePage({ params }: Props) {
+  const { token } = await params;
+  return <ClientSpaceClient token={token} />;
+}

--- a/app/client-space/[token]/summary/SummaryClient.tsx
+++ b/app/client-space/[token]/summary/SummaryClient.tsx
@@ -1,0 +1,615 @@
+'use client';
+
+import { useEffect, useState, type ReactNode } from 'react';
+import Image from 'next/image';
+import {
+  getClientPreparation,
+  getCharterByClientSpaceToken,
+  CHECKLIST_CATEGORIES,
+  type ClientPreparation,
+} from '../../../../lib/clientSpace';
+import type { Charter } from '../../../../lib/availability';
+import { getMarinaById } from '../../../marinas-data';
+import { CONTACT } from '../../../config/contact';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fmtDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+
+function nightCount(start: string, end: string) {
+  return Math.round((new Date(end).getTime() - new Date(start).getTime()) / 86400000);
+}
+
+const SODA_TYPES = [
+  'Coke 0.5 l', 'Diet Coke 0.5 l', 'Sprite 0.5 l', 'Pepsi 0.5 l',
+  'Orange Juice 1.0 l', 'Apple Juice 1.0 l', 'Cranberry Juice 1.0 l',
+  'Tonic Water 1.5 l', 'Water Still 0.5 l', 'Water Sparkling 0.5 l',
+];
+const WINE_TYPES = ['White Wine', 'Red Wine', 'Rosé Wine', 'Champagne / Sparkling'];
+const SPIRIT_TYPES = [
+  'Vodka', 'Gin', 'Rum', 'Whisky / Scotch', 'Tequila',
+  'Beer (local)', 'Beer (imported)', 'Liqueurs',
+];
+const FOOD_CATEGORIES = ['Seafood', 'Meat', 'Fruit', 'Vegetables', 'Dairy', 'Other'] as const;
+const BREAKFAST_STYLE_LABELS: Record<string, string> = {
+  light: 'Light / Cold',
+  american: 'American (pancakes, muffins)',
+  full: 'Full Cooked (eggs, bacon, sausage)',
+};
+
+// ---------------------------------------------------------------------------
+// Print styles (injected as a <style> tag, only active on screen + print)
+// ---------------------------------------------------------------------------
+
+const PRINT_STYLES = `
+  @media print {
+    .no-print { display: none !important; }
+    .print-page-break { page-break-before: always; }
+    body { background: white !important; color: #1a1a2e !important; }
+    * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+
+    .summary-header {
+      background: #27368B !important;
+      color: white !important;
+      padding: 1.5rem 2rem !important;
+      display: flex !important;
+      justify-content: space-between !important;
+      align-items: flex-start !important;
+    }
+    .summary-section {
+      border: 1px solid #e2e8f0 !important;
+      border-radius: 0 !important;
+      margin-bottom: 0 !important;
+      page-break-inside: avoid;
+    }
+    .summary-section-title {
+      background: #27368B !important;
+      color: white !important;
+      font-weight: 700;
+      font-size: 0.75rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      padding: 0.5rem 1rem;
+    }
+    .summary-subsection-title {
+      background: #1F8FCA !important;
+      color: white !important;
+    }
+    .summary-footer {
+      border-top: 2px solid #27368B !important;
+      padding-top: 0.75rem !important;
+      margin-top: 2rem !important;
+      font-size: 0.7rem;
+      color: #64748b;
+    }
+    .checklist-item-done { color: #16a34a !important; }
+    .checklist-item-pending { color: #94a3b8 !important; }
+  }
+
+  @media screen {
+    .summary-header {
+      background: linear-gradient(135deg, #27368B 0%, #1F8FCA 100%);
+    }
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function SectionTitle({ children }: { children: ReactNode }) {
+  return (
+    <div className="summary-section-title px-5 py-2.5 text-xs font-bold uppercase tracking-widest text-white" style={{ background: '#27368B' }}>
+      {children}
+    </div>
+  );
+}
+
+function SubsectionTitle({ children }: { children: ReactNode }) {
+  return (
+    <div className="summary-subsection-title px-5 py-1.5 text-xs font-semibold text-white" style={{ background: '#1F8FCA' }}>
+      {children}
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value?: string | number | null }) {
+  if (!value && value !== 0) return null;
+  return (
+    <div className="flex gap-4 py-1.5 border-b border-slate-100 last:border-0 px-5">
+      <span className="text-xs font-semibold text-slate-500 w-40 flex-shrink-0">{label}</span>
+      <span className="text-xs text-slate-800">{value}</span>
+    </div>
+  );
+}
+
+function BoolRow({ label, value }: { label: string; value?: boolean | null }) {
+  if (value === undefined || value === null) return null;
+  return (
+    <div className="flex gap-4 py-1.5 border-b border-slate-100 last:border-0 px-5">
+      <span className="text-xs font-semibold text-slate-500 w-40 flex-shrink-0">{label}</span>
+      <span className="text-xs text-slate-800">{value ? 'Yes' : 'No'}</span>
+    </div>
+  );
+}
+
+function TagList({ label, values }: { label: string; values?: string[] }) {
+  if (!values?.length) return null;
+  return (
+    <div className="flex gap-4 py-1.5 border-b border-slate-100 last:border-0 px-5 items-start">
+      <span className="text-xs font-semibold text-slate-500 w-40 flex-shrink-0">{label}</span>
+      <div className="flex flex-wrap gap-1">
+        {values.map(v => (
+          <span key={v} className="text-xs bg-blue-50 text-blue-700 px-2 py-0.5 rounded-full">{v}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EmptySection({ message }: { message: string }) {
+  return (
+    <p className="px-5 py-3 text-xs text-slate-400 italic">{message}</p>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section components
+// ---------------------------------------------------------------------------
+
+function CharterSection({ charter }: { charter: Charter }) {
+  const delivery = getMarinaById(charter.deliveryPoint ?? '');
+  const redelivery = getMarinaById(charter.redeliveryPoint ?? charter.deliveryPoint ?? '');
+  const nights = charter.startDate && charter.endDate ? nightCount(charter.startDate, charter.endDate) : null;
+
+  return (
+    <div className="summary-section border border-slate-200 rounded-xl overflow-hidden mb-4">
+      <SectionTitle>Charter Details</SectionTitle>
+      <div className="py-1">
+        <Row label="Client Name" value={charter.name} />
+        <Row label="Email" value={charter.email} />
+        <Row label="Phone" value={charter.phone} />
+        <Row label="Vessel" value={charter.boat ?? 'BlueOne — Fountaine Pajot Aura 51'} />
+        <Row label="Start Date" value={charter.startDate ? fmtDate(charter.startDate) : undefined} />
+        <Row label="End Date" value={charter.endDate ? `${fmtDate(charter.endDate)}${nights ? ` (${nights} nights)` : ''}` : undefined} />
+        <Row label="Guests" value={charter.passengers ? `${charter.passengers} passenger${charter.passengers > 1 ? 's' : ''}` : undefined} />
+        <Row label="Embarkation" value={delivery?.name ?? charter.embarkationPoint} />
+        <Row label="Disembarkation" value={redelivery?.name ?? delivery?.name} />
+        <Row label="Experience Theme" value={charter.selectedTheme} />
+        <Row label="Holiday Vision" value={charter.holidayDescription} />
+      </div>
+    </div>
+  );
+}
+
+function CrewSection({ prep }: { prep: ClientPreparation }) {
+  const crew = prep.crew ?? [];
+  return (
+    <div className="summary-section border border-slate-200 rounded-xl overflow-hidden mb-4">
+      <SectionTitle>Crew / Passenger Details</SectionTitle>
+      {crew.length === 0 ? (
+        <EmptySection message="No crew details submitted yet." />
+      ) : (
+        crew.map((m, i) => (
+          <div key={i}>
+            <SubsectionTitle>Passenger {i + 1}{m.firstName || m.lastName ? ` — ${m.firstName} ${m.lastName}`.trimEnd() : ''}</SubsectionTitle>
+            <div className="py-1">
+              <Row label="Full Name" value={`${m.firstName ?? ''} ${m.lastName ?? ''}`.trim() || undefined} />
+              <Row label="Gender" value={m.gender} />
+              <Row label="Date of Birth" value={m.dateOfBirth ? fmtDate(m.dateOfBirth) : undefined} />
+              <Row label="Nationality" value={m.nationality} />
+              <Row label="Passport Number" value={m.passportNumber} />
+              <Row label="Dietary Restrictions" value={m.dietaryRestrictions} />
+              <Row label="Medical Notes" value={m.medicalNotes} />
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function TravelSection({ prep }: { prep: ClientPreparation }) {
+  const t = prep.travel ?? {};
+  const hasArrival = t.arrivalDate || t.arrivalFlight;
+  const hasDeparture = t.departureDate || t.departureFlight;
+  const hasAny = hasArrival || hasDeparture || t.stayingAtHotel != null || t.transferFromAirport != null;
+
+  return (
+    <div className="summary-section border border-slate-200 rounded-xl overflow-hidden mb-4">
+      <SectionTitle>Travel & Logistics</SectionTitle>
+      {!hasAny ? (
+        <EmptySection message="No travel details submitted yet." />
+      ) : (
+        <>
+          {hasArrival && (
+            <>
+              <SubsectionTitle>Arrival</SubsectionTitle>
+              <div className="py-1">
+                <Row label="Arrival Date" value={t.arrivalDate ? fmtDate(t.arrivalDate) : undefined} />
+                <Row label="Arrival Time" value={t.arrivalTime} />
+                <Row label="Flight Number" value={t.arrivalFlight} />
+                <BoolRow label="Staying at Hotel" value={t.stayingAtHotel} />
+                <Row label="Hotel Name" value={t.hotelName} />
+                <BoolRow label="Airport Transfer Needed" value={t.transferFromAirport} />
+              </div>
+            </>
+          )}
+          {hasDeparture && (
+            <>
+              <SubsectionTitle>Departure</SubsectionTitle>
+              <div className="py-1">
+                <Row label="Departure Date" value={t.departureDate ? fmtDate(t.departureDate) : undefined} />
+                <Row label="Departure Time" value={t.departureTime} />
+                <Row label="Flight Number" value={t.departureFlight} />
+                <BoolRow label="Airport Transfer Needed" value={t.transferToAirport} />
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function ActivitiesSection({ prep }: { prep: ClientPreparation }) {
+  const a = prep.activities ?? {};
+  const groupStyleLabel = a.groupStyle === 'active' ? 'Active & on the go' : a.groupStyle === 'relaxed' ? 'Relaxed & laid-back' : a.groupStyle === 'combination' ? 'A bit of both' : undefined;
+
+  return (
+    <div className="summary-section border border-slate-200 rounded-xl overflow-hidden mb-4">
+      <SectionTitle>Activities & Health</SectionTitle>
+      <div className="py-1">
+        <Row label="Group Style" value={groupStyleLabel} />
+        <Row label="Specific Places" value={a.specificPlaces} />
+        <TagList label="Activities" values={a.activities} />
+        <Row label="Medical Information" value={a.healthNotes} />
+        <Row label="Sailing Experience" value={a.sailingExperience} />
+        {!groupStyleLabel && !a.specificPlaces && !a.activities?.length && !a.healthNotes && !a.sailingExperience && (
+          <EmptySection message="No activity or health details submitted yet." />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FoodSection({ prep }: { prep: ClientPreparation }) {
+  const f = prep.food ?? {};
+  const hasFoodData = FOOD_CATEGORIES.some(cat => {
+    const key = cat.toLowerCase() as keyof typeof f;
+    const catData = f[key] as { likes?: string; dislikes?: string; allergies?: string } | undefined;
+    return catData?.likes || catData?.dislikes || catData?.allergies;
+  });
+  const hasBreakfast = f.breakfastStyle?.length || f.breakfastItems?.length;
+  const hasMeals = f.lunchStyle || f.dinnerStyle;
+
+  return (
+    <div className="summary-section border border-slate-200 rounded-xl overflow-hidden mb-4">
+      <SectionTitle>Food Preferences</SectionTitle>
+
+      {hasFoodData && (
+        <>
+          <SubsectionTitle>Food Categories</SubsectionTitle>
+          <div className="py-1">
+            <div className="grid grid-cols-4 gap-0 px-5 py-1 border-b border-slate-100">
+              <span className="text-[10px] font-bold text-slate-400 uppercase">Category</span>
+              <span className="text-[10px] font-bold text-slate-400 uppercase">Likes</span>
+              <span className="text-[10px] font-bold text-slate-400 uppercase">Dislikes</span>
+              <span className="text-[10px] font-bold text-slate-400 uppercase">Allergies</span>
+            </div>
+            {FOOD_CATEGORIES.map(cat => {
+              const key = cat.toLowerCase() as keyof typeof f;
+              const catData = f[key] as { likes?: string; dislikes?: string; allergies?: string } | undefined;
+              if (!catData?.likes && !catData?.dislikes && !catData?.allergies) return null;
+              return (
+                <div key={cat} className="grid grid-cols-4 gap-0 px-5 py-1.5 border-b border-slate-100 last:border-0">
+                  <span className="text-xs font-semibold text-slate-700">{cat}</span>
+                  <span className="text-xs text-slate-600">{catData?.likes || '—'}</span>
+                  <span className="text-xs text-slate-600">{catData?.dislikes || '—'}</span>
+                  <span className="text-xs text-slate-600">{catData?.allergies || '—'}</span>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      {hasBreakfast && (
+        <>
+          <SubsectionTitle>Breakfast</SubsectionTitle>
+          <div className="py-1">
+            {f.breakfastStyle?.length ? (
+              <TagList label="Style" values={f.breakfastStyle.map(s => BREAKFAST_STYLE_LABELS[s] ?? s)} />
+            ) : null}
+            <TagList label="Items" values={f.breakfastItems} />
+          </div>
+        </>
+      )}
+
+      {hasMeals && (
+        <>
+          <SubsectionTitle>Lunch & Dinner</SubsectionTitle>
+          <div className="py-1">
+            <Row label="Lunch Style" value={f.lunchStyle} />
+            <BoolRow label="Lunch Dessert" value={f.lunchDessert} />
+            <Row label="Lunch Snacks" value={f.lunchSnacks} />
+            <Row label="Dinner Style" value={f.dinnerStyle} />
+            <BoolRow label="Dinner Dessert" value={f.dinnerDessert} />
+          </div>
+        </>
+      )}
+
+      {!hasFoodData && !hasBreakfast && !hasMeals && (
+        <EmptySection message="No food preferences submitted yet." />
+      )}
+    </div>
+  );
+}
+
+function BeveragesSection({ prep }: { prep: ClientPreparation }) {
+  const b = prep.beverages ?? {};
+
+  const allTypes = [
+    { types: SODA_TYPES, group: 'sodas' as const, label: 'Sodas, Juices & Water' },
+    { types: WINE_TYPES, group: 'wines' as const, label: 'Wines & Sparkling' },
+    { types: SPIRIT_TYPES, group: 'spirits' as const, label: 'Spirits & Beer' },
+  ];
+
+  const hasBarData = allTypes.some(({ types, group }) =>
+    types.some(t => {
+      const item = (b[group] ?? {})[t];
+      return item && (item.qty || item.preferredBrand);
+    })
+  );
+
+  const hasWarm = b.warmBeverages?.length || b.warmBeveragesOther;
+
+  return (
+    <div className="summary-section border border-slate-200 rounded-xl overflow-hidden mb-4">
+      <SectionTitle>Beverages & Bar</SectionTitle>
+
+      {hasWarm && (
+        <>
+          <SubsectionTitle>Hot Beverages</SubsectionTitle>
+          <div className="py-1">
+            <TagList label="Selections" values={b.warmBeverages} />
+            <Row label="Other" value={b.warmBeveragesOther} />
+          </div>
+        </>
+      )}
+
+      {hasBarData && allTypes.map(({ types, group, label }) => {
+        const rows = types.filter(t => {
+          const item = (b[group] ?? {})[t];
+          return item && (item.qty || item.preferredBrand);
+        });
+        if (!rows.length) return null;
+        return (
+          <div key={group}>
+            <SubsectionTitle>{label}</SubsectionTitle>
+            <div className="py-1">
+              <div className="grid grid-cols-3 px-5 py-1 border-b border-slate-100">
+                <span className="text-[10px] font-bold text-slate-400 uppercase">Item</span>
+                <span className="text-[10px] font-bold text-slate-400 uppercase">Qty</span>
+                <span className="text-[10px] font-bold text-slate-400 uppercase">Brand / Notes</span>
+              </div>
+              {rows.map(t => {
+                const item = (b[group] ?? {})[t] ?? {};
+                return (
+                  <div key={t} className="grid grid-cols-3 px-5 py-1.5 border-b border-slate-100 last:border-0">
+                    <span className="text-xs text-slate-700">{t}</span>
+                    <span className="text-xs text-slate-600">{item.qty ?? '—'}</span>
+                    <span className="text-xs text-slate-600">{item.preferredBrand || item.remarks || '—'}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+
+      {!hasWarm && !hasBarData && (
+        <EmptySection message="No beverage preferences submitted yet." />
+      )}
+    </div>
+  );
+}
+
+function SpecialSection({ prep }: { prep: ClientPreparation }) {
+  const s = prep.special ?? {};
+  const hasContact = s.emergencyContactName || s.emergencyContactPhone;
+  const hasAny = s.celebration || s.musicAtmosphere || s.petsOnBoard || s.extraNotes || hasContact;
+
+  return (
+    <div className="summary-section border border-slate-200 rounded-xl overflow-hidden mb-4">
+      <SectionTitle>Special Requests</SectionTitle>
+      {!hasAny ? (
+        <EmptySection message="No special requests submitted yet." />
+      ) : (
+        <div className="py-1">
+          <Row label="Special Occasion" value={s.celebration} />
+          <Row label="Music Atmosphere" value={s.musicAtmosphere} />
+          <Row label="Pets on Board" value={s.petsOnBoard} />
+          {hasContact && (
+            <Row
+              label="Emergency Contact"
+              value={[s.emergencyContactName, s.emergencyContactPhone, s.emergencyContactRelation].filter(Boolean).join(' · ')}
+            />
+          )}
+          <Row label="Additional Notes" value={s.extraNotes} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChecklistSection({ prep }: { prep: ClientPreparation }) {
+  const checklist = prep.checklist ?? {};
+  const allItems = CHECKLIST_CATEGORIES.flatMap(c => c.items);
+  const doneCount = allItems.filter(i => checklist[i.id]).length;
+
+  return (
+    <div className="summary-section border border-slate-200 rounded-xl overflow-hidden mb-4">
+      <SectionTitle>Pre-Departure Checklist — {doneCount} / {allItems.length} completed</SectionTitle>
+      {CHECKLIST_CATEGORIES.map(cat => (
+        <div key={cat.id}>
+          <SubsectionTitle>{cat.label}</SubsectionTitle>
+          <div className="py-1 px-5 space-y-1">
+            {cat.items.map(item => (
+              <div key={item.id} className="flex items-center gap-2.5 py-0.5">
+                <span className={`flex-shrink-0 w-4 h-4 rounded-full border-2 flex items-center justify-center text-[9px] font-bold ${
+                  checklist[item.id]
+                    ? 'border-emerald-500 bg-emerald-500 text-white checklist-item-done'
+                    : 'border-slate-300 checklist-item-pending'
+                }`}>
+                  {checklist[item.id] ? '✓' : ''}
+                </span>
+                <span className={`text-xs ${checklist[item.id] ? 'text-emerald-700 line-through' : 'text-slate-500'}`}>
+                  {item.label}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+interface Props { token: string }
+
+export default function SummaryClient({ token }: Props) {
+  const [charter, setCharter] = useState<Charter | null>(null);
+  const [prep, setPrep] = useState<ClientPreparation | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    Promise.all([
+      getCharterByClientSpaceToken(token),
+      getClientPreparation(token),
+    ])
+      .then(([c, p]) => {
+        if (!c || !p) { setNotFound(true); return; }
+        setCharter(c);
+        setPrep(p);
+      })
+      .catch(() => setNotFound(true))
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-slate-50">
+        <p className="text-slate-400 text-sm animate-pulse">Loading summary…</p>
+      </div>
+    );
+  }
+
+  if (notFound || !charter || !prep) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-slate-50">
+        <div className="text-center">
+          <p className="text-slate-500 text-sm">Summary not found.</p>
+          <p className="text-slate-400 text-xs mt-1">
+            Contact us at <a href={`mailto:${CONTACT.email}`} className="underline">{CONTACT.email}</a>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const printedAt = new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+
+  return (
+    <>
+      <style dangerouslySetInnerHTML={{ __html: PRINT_STYLES }} />
+
+      <div className="min-h-screen bg-slate-50">
+
+        {/* Screen header */}
+        <div className="summary-header no-print sticky top-0 z-30 px-6 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <Image
+              src="/images/boats/blueone/logo_blueone.png"
+              alt="BlueOne"
+              width={100}
+              height={40}
+              className="object-contain"
+              unoptimized
+            />
+            <div>
+              <p className="text-white font-bold text-base leading-tight">Preference Summary</p>
+              {charter.name && <p className="text-blue-200 text-xs">{charter.name} · {charter.startDate ? fmtDate(charter.startDate) : '—'}</p>}
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <a
+              href={`/client-space/${token}`}
+              className="no-print px-4 py-2 rounded-xl text-xs font-semibold border border-white/30 text-white hover:bg-white/10 transition-colors"
+            >
+              ← Edit Preferences
+            </a>
+            <button
+              onClick={() => window.print()}
+              className="no-print px-5 py-2 rounded-xl text-xs font-bold bg-white text-blue-800 hover:bg-blue-50 transition-colors shadow-sm flex items-center gap-2"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
+              </svg>
+              Print / Save PDF
+            </button>
+          </div>
+        </div>
+
+        {/* Print-only header (hidden on screen) */}
+        <div className="hidden print:block summary-header px-8 py-5 mb-6" style={{ background: '#27368B' }}>
+          <div className="flex justify-between items-start">
+            <div>
+              <p className="text-white font-bold text-lg">BlueOne Yacht Charter</p>
+              <p className="text-blue-200 text-sm">Holiday Preference Summary</p>
+            </div>
+            <div className="text-right">
+              <p className="text-white font-semibold text-sm">{charter.name ?? ''}</p>
+              <p className="text-blue-200 text-xs">
+                {charter.startDate ? fmtDate(charter.startDate) : '—'}
+                {charter.endDate ? ` – ${fmtDate(charter.endDate)}` : ''}
+              </p>
+              <p className="text-blue-300 text-xs mt-0.5">Printed: {printedAt}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="max-w-4xl mx-auto px-4 py-8 space-y-4">
+
+          <CharterSection charter={charter} />
+          <CrewSection prep={prep} />
+          <TravelSection prep={prep} />
+          <ActivitiesSection prep={prep} />
+          <FoodSection prep={prep} />
+          <BeveragesSection prep={prep} />
+          <SpecialSection prep={prep} />
+          <ChecklistSection prep={prep} />
+
+          {/* Footer */}
+          <div className="summary-footer pt-6 border-t border-slate-200 text-center">
+            <p className="text-xs text-slate-400">
+              BlueOne Luxury Yacht Charters · {CONTACT.email} · Generated {printedAt}
+            </p>
+            <p className="text-xs text-slate-400 mt-1">
+              This document is confidential and intended solely for BlueOne crew and charter management.
+            </p>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/client-space/[token]/summary/SummaryClient.tsx
+++ b/app/client-space/[token]/summary/SummaryClient.tsx
@@ -359,7 +359,8 @@ function FoodSection({ prep }: { prep: ClientPreparation }) {
         <>
           <SubsectionTitle>Food Categories</SubsectionTitle>
           <div className="py-1">
-            <div className="grid grid-cols-4 gap-0 px-5 py-1 border-b border-slate-100">
+            {/* Desktop: 4-column grid */}
+            <div className="hidden sm:grid grid-cols-4 gap-0 px-5 py-1 border-b border-slate-100">
               <span className="text-[10px] font-bold text-slate-400 uppercase">Category</span>
               <span className="text-[10px] font-bold text-slate-400 uppercase">Likes</span>
               <span className="text-[10px] font-bold text-slate-400 uppercase">Dislikes</span>
@@ -370,11 +371,21 @@ function FoodSection({ prep }: { prep: ClientPreparation }) {
               const catData = f[key] as { likes?: string; dislikes?: string; allergies?: string } | undefined;
               if (!catData?.likes && !catData?.dislikes && !catData?.allergies) return null;
               return (
-                <div key={cat} className="grid grid-cols-4 gap-0 px-5 py-1.5 border-b border-slate-100 last:border-0">
-                  <span className="text-xs font-semibold text-slate-700">{cat}</span>
-                  <span className="text-xs text-slate-600">{catData?.likes || '—'}</span>
-                  <span className="text-xs text-slate-600">{catData?.dislikes || '—'}</span>
-                  <span className="text-xs text-slate-600">{catData?.allergies || '—'}</span>
+                <div key={cat} className="border-b border-slate-100 last:border-0">
+                  {/* Desktop row */}
+                  <div className="hidden sm:grid grid-cols-4 gap-0 px-5 py-1.5">
+                    <span className="text-xs font-semibold text-slate-700">{cat}</span>
+                    <span className="text-xs text-slate-600">{catData?.likes || '—'}</span>
+                    <span className="text-xs text-slate-600">{catData?.dislikes || '—'}</span>
+                    <span className="text-xs text-slate-600">{catData?.allergies || '—'}</span>
+                  </div>
+                  {/* Mobile: stacked */}
+                  <div className="sm:hidden px-5 py-2 space-y-0.5">
+                    <p className="text-xs font-semibold text-slate-700">{cat}</p>
+                    {catData?.likes && <p className="text-xs text-slate-600"><span className="text-slate-400">Likes: </span>{catData.likes}</p>}
+                    {catData?.dislikes && <p className="text-xs text-slate-600"><span className="text-slate-400">Dislikes: </span>{catData.dislikes}</p>}
+                    {catData?.allergies && <p className="text-xs text-red-600 font-medium"><span className="text-slate-400">Allergies: </span>{catData.allergies}</p>}
+                  </div>
                 </div>
               );
             })}
@@ -456,18 +467,29 @@ function BeveragesSection({ prep }: { prep: ClientPreparation }) {
           <div key={group}>
             <SubsectionTitle>{label}</SubsectionTitle>
             <div className="py-1">
-              <div className="grid grid-cols-3 px-5 py-1 border-b border-slate-100">
+              {/* Desktop: 3-column grid */}
+              <div className="hidden sm:grid grid-cols-3 px-5 py-1 border-b border-slate-100">
                 <span className="text-[10px] font-bold text-slate-400 uppercase">Item</span>
                 <span className="text-[10px] font-bold text-slate-400 uppercase">Qty</span>
                 <span className="text-[10px] font-bold text-slate-400 uppercase">Brand / Notes</span>
               </div>
               {rows.map(t => {
                 const item = (b[group] ?? {})[t] ?? {};
+                const brand = item.preferredBrand || item.remarks;
                 return (
-                  <div key={t} className="grid grid-cols-3 px-5 py-1.5 border-b border-slate-100 last:border-0">
-                    <span className="text-xs text-slate-700">{t}</span>
-                    <span className="text-xs text-slate-600">{item.qty ?? '—'}</span>
-                    <span className="text-xs text-slate-600">{item.preferredBrand || item.remarks || '—'}</span>
+                  <div key={t} className="border-b border-slate-100 last:border-0">
+                    {/* Desktop row */}
+                    <div className="hidden sm:grid grid-cols-3 px-5 py-1.5">
+                      <span className="text-xs text-slate-700">{t}</span>
+                      <span className="text-xs text-slate-600">{item.qty ?? '—'}</span>
+                      <span className="text-xs text-slate-600">{brand || '—'}</span>
+                    </div>
+                    {/* Mobile: compact inline */}
+                    <div className="sm:hidden flex items-baseline justify-between px-5 py-1.5 gap-3">
+                      <span className="text-xs text-slate-700 flex-1">{t}</span>
+                      <span className="text-xs text-slate-500 flex-shrink-0">×{item.qty ?? '—'}</span>
+                      {brand && <span className="text-xs text-slate-400 flex-shrink-0 truncate max-w-[100px]">{brand}</span>}
+                    </div>
                   </div>
                 );
               })}
@@ -600,36 +622,42 @@ export default function SummaryClient({ token }: Props) {
       <div className="min-h-screen bg-slate-50">
 
         {/* Screen header */}
-        <div className="summary-header no-print sticky top-0 z-30 px-6 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-4">
+        <div className="summary-header no-print sticky top-0 z-30 px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 sm:gap-4 min-w-0">
             <Image
               src="/images/boats/blueone/logo_blueone.png"
               alt="BlueOne"
-              width={100}
-              height={40}
-              className="object-contain"
+              width={72}
+              height={28}
+              className="object-contain flex-shrink-0 sm:w-[100px] sm:h-[40px]"
               unoptimized
             />
-            <div>
-              <p className="text-white font-bold text-base leading-tight">Preference Summary</p>
-              {charter.name && <p className="text-blue-200 text-xs">{charter.name} · {charter.startDate ? fmtDate(charter.startDate) : '—'}</p>}
+            <div className="min-w-0">
+              <p className="text-white font-bold text-sm sm:text-base leading-tight">Preference Summary</p>
+              {charter.name && <p className="text-blue-200 text-[10px] sm:text-xs truncate">{charter.name} · {charter.startDate ? fmtDate(charter.startDate) : '—'}</p>}
             </div>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {/* Back link — icon-only on mobile, full text on sm+ */}
             <a
               href={`/client-space/${token}`}
-              className="no-print px-4 py-2 rounded-xl text-xs font-semibold border border-white/30 text-white hover:bg-white/10 transition-colors"
+              className="no-print flex items-center gap-1.5 px-2 sm:px-4 py-2 rounded-xl text-xs font-semibold border border-white/30 text-white hover:bg-white/10 transition-colors"
+              aria-label="Edit Preferences"
             >
-              ← Edit Preferences
+              <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+              <span className="hidden sm:inline">Edit Preferences</span>
             </a>
             <button
               onClick={() => window.print()}
-              className="no-print px-5 py-2 rounded-xl text-xs font-bold bg-white text-blue-800 hover:bg-blue-50 transition-colors shadow-sm flex items-center gap-2"
+              className="no-print flex items-center gap-1.5 px-3 sm:px-5 py-2 rounded-xl text-xs font-bold bg-white text-blue-800 hover:bg-blue-50 transition-colors shadow-sm"
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
               </svg>
-              Print / Save PDF
+              <span className="hidden xs:inline sm:inline">Print / Save PDF</span>
+              <span className="sm:hidden">Print</span>
             </button>
           </div>
         </div>

--- a/app/client-space/[token]/summary/SummaryClient.tsx
+++ b/app/client-space/[token]/summary/SummaryClient.tsx
@@ -212,8 +212,73 @@ function CrewSection({ prep }: { prep: ClientPreparation }) {
   );
 }
 
+function TravelGroupBlock({ group, index, crew }: {
+  group: import('../../../../lib/clientSpace').TravelGroup;
+  index: number;
+  crew: import('../../../../lib/clientSpace').CrewMember[];
+}) {
+  const hasArrival = group.arrivalDate || group.arrivalFlight;
+  const hasDeparture = group.departureDate || group.departureFlight;
+  const memberNames = group.memberIndices
+    .map(i => {
+      const m = crew[i];
+      if (!m) return `Passenger ${i + 1}`;
+      return [m.firstName, m.lastName].filter(Boolean).join(' ') || `Passenger ${i + 1}`;
+    })
+    .join(', ');
+
+  return (
+    <div>
+      <SubsectionTitle>Group {index + 1}{memberNames ? ` — ${memberNames}` : ''}</SubsectionTitle>
+      {hasArrival && (
+        <div className="py-1">
+          <div className="px-5 py-1 text-[10px] font-bold text-slate-400 uppercase border-b border-slate-100">Arrival</div>
+          <Row label="Arrival Date" value={group.arrivalDate ? fmtDate(group.arrivalDate) : undefined} />
+          <Row label="Arrival Time" value={group.arrivalTime} />
+          <Row label="Flight Number" value={group.arrivalFlight} />
+          <BoolRow label="Staying at Hotel" value={group.stayingAtHotel} />
+          <Row label="Hotel Name" value={group.hotelName} />
+          <BoolRow label="Airport Transfer" value={group.transferFromAirport} />
+        </div>
+      )}
+      {hasDeparture && (
+        <div className="py-1">
+          <div className="px-5 py-1 text-[10px] font-bold text-slate-400 uppercase border-b border-slate-100">Departure</div>
+          <Row label="Departure Date" value={group.departureDate ? fmtDate(group.departureDate) : undefined} />
+          <Row label="Departure Time" value={group.departureTime} />
+          <Row label="Flight Number" value={group.departureFlight} />
+          <BoolRow label="Airport Transfer" value={group.transferToAirport} />
+        </div>
+      )}
+      {!hasArrival && !hasDeparture && (
+        <p className="px-5 py-2 text-xs text-slate-400 italic">No details entered for this group.</p>
+      )}
+    </div>
+  );
+}
+
 function TravelSection({ prep }: { prep: ClientPreparation }) {
   const t = prep.travel ?? {};
+  const groups = t.groups ?? [];
+
+  // Groups mode (new UI)
+  if (groups.length > 0) {
+    const hasAnyGroupData = groups.some(g => g.arrivalDate || g.arrivalFlight || g.departureDate || g.departureFlight);
+    return (
+      <div className="summary-section border border-slate-200 rounded-xl overflow-hidden mb-4">
+        <SectionTitle>Travel & Logistics</SectionTitle>
+        {!hasAnyGroupData ? (
+          <EmptySection message="No travel details submitted yet." />
+        ) : (
+          groups.map((g, i) => (
+            <TravelGroupBlock key={g.id} group={g} index={i} crew={prep.crew ?? []} />
+          ))
+        )}
+      </div>
+    );
+  }
+
+  // Legacy flat-field fallback
   const hasArrival = t.arrivalDate || t.arrivalFlight;
   const hasDeparture = t.departureDate || t.departureFlight;
   const hasAny = hasArrival || hasDeparture || t.stayingAtHotel != null || t.transferFromAirport != null;

--- a/app/client-space/[token]/summary/page.tsx
+++ b/app/client-space/[token]/summary/page.tsx
@@ -1,0 +1,16 @@
+import { type Metadata } from 'next';
+import SummaryClient from './SummaryClient';
+
+export const metadata: Metadata = {
+  title: 'Preference Summary | BlueOne Luxury Yacht Charters',
+  robots: { index: false, follow: false },
+};
+
+interface Props {
+  params: Promise<{ token: string }>;
+}
+
+export default async function SummaryPage({ params }: Props) {
+  const { token } = await params;
+  return <SummaryClient token={token} />;
+}

--- a/app/components/SiteChrome.tsx
+++ b/app/components/SiteChrome.tsx
@@ -7,7 +7,7 @@ import Footer from './Footer';
 
 export default function SiteChrome({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const bare = pathname?.startsWith('/proposal/') ?? false;
+  const bare = (pathname?.startsWith('/proposal/') || pathname?.startsWith('/client-space/')) ?? false;
 
   return (
     <>

--- a/lib/availability.ts
+++ b/lib/availability.ts
@@ -208,6 +208,8 @@ export interface Charter {
   createdAt: Timestamp | null;
   // Proposal sub-object (present once a proposal is created for this charter)
   proposal?: ProposalData;
+  // Client preparation space token (present once the admin generates the link)
+  clientSpaceToken?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/clientSpace.ts
+++ b/lib/clientSpace.ts
@@ -49,6 +49,7 @@ export interface FoodCategory {
   likes?: string;
   dislikes?: string;
   allergies?: string;
+  passengerNotes?: Record<string, string>;
 }
 
 export interface FoodPreferences {
@@ -71,6 +72,7 @@ export interface BeverageItem {
   preferredBrand?: string;
   qty?: number;
   remarks?: string;
+  passengerNotes?: Record<string, string>;
 }
 
 export interface BeveragePreferences {

--- a/lib/clientSpace.ts
+++ b/lib/clientSpace.ts
@@ -4,10 +4,13 @@ import {
   getDoc,
   getDocs,
   setDoc,
+  addDoc,
   updateDoc,
   serverTimestamp,
   query,
   where,
+  orderBy,
+  limit,
   type Timestamp,
 } from 'firebase/firestore';
 import { db } from './firebase';
@@ -111,6 +114,13 @@ export interface ClientPreparation {
   updatedAt: Timestamp | null;
   completedAt?: Timestamp | null;
 }
+
+export type PrepSnapshot = {
+  id: string;
+  label: string;
+  savedAt: Timestamp;
+  data: Pick<ClientPreparation, 'crew' | 'travel' | 'activities' | 'food' | 'beverages' | 'special' | 'checklist' | 'lastSavedStep'>;
+};
 
 // ---------------------------------------------------------------------------
 // Pre-departure checklist definition
@@ -277,4 +287,46 @@ export async function saveChecklist(token: string, checklist: Record<string, boo
 
 export async function saveStep(token: string, step: number): Promise<void> {
   await updateDoc(doc(db, COLLECTION, token), { lastSavedStep: step, updatedAt: serverTimestamp() });
+}
+
+// ---------------------------------------------------------------------------
+// History (subcollection: clientPreparations/{token}/history)
+// ---------------------------------------------------------------------------
+
+const HISTORY_LIMIT = 30;
+
+export async function saveSnapshot(
+  token: string,
+  prep: ClientPreparation,
+  label: string
+): Promise<void> {
+  const historyCol = collection(db, COLLECTION, token, 'history');
+  await addDoc(historyCol, {
+    label,
+    savedAt: serverTimestamp(),
+    data: {
+      crew: prep.crew,
+      travel: prep.travel,
+      activities: prep.activities,
+      food: prep.food,
+      beverages: prep.beverages,
+      special: prep.special,
+      checklist: prep.checklist,
+      lastSavedStep: prep.lastSavedStep,
+    },
+  });
+}
+
+export async function getHistory(token: string): Promise<PrepSnapshot[]> {
+  const historyCol = collection(db, COLLECTION, token, 'history');
+  const q = query(historyCol, orderBy('savedAt', 'desc'), limit(HISTORY_LIMIT));
+  const snap = await getDocs(q);
+  return snap.docs.map(d => ({ id: d.id, ...d.data() } as PrepSnapshot));
+}
+
+export async function restoreSnapshot(token: string, snapshot: PrepSnapshot): Promise<void> {
+  await updateDoc(doc(db, COLLECTION, token), {
+    ...snapshot.data,
+    updatedAt: serverTimestamp(),
+  });
 }

--- a/lib/clientSpace.ts
+++ b/lib/clientSpace.ts
@@ -1,0 +1,280 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  setDoc,
+  updateDoc,
+  serverTimestamp,
+  query,
+  where,
+  type Timestamp,
+} from 'firebase/firestore';
+import { db } from './firebase';
+import type { Charter } from './availability';
+import { updateCharter } from './availability';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CrewMember {
+  firstName: string;
+  lastName: string;
+  gender?: string;
+  dateOfBirth?: string;
+  nationality?: string;
+  passportNumber?: string;
+  dietaryRestrictions?: string;
+  medicalNotes?: string;
+}
+
+export interface TravelLogistics {
+  arrivalDate?: string;
+  arrivalTime?: string;
+  arrivalFlight?: string;
+  stayingAtHotel?: boolean;
+  hotelName?: string;
+  transferFromAirport?: boolean;
+  departureDate?: string;
+  departureTime?: string;
+  departureFlight?: string;
+  transferToAirport?: boolean;
+}
+
+export interface FoodCategory {
+  likes?: string;
+  dislikes?: string;
+  allergies?: string;
+}
+
+export interface FoodPreferences {
+  seafood?: FoodCategory;
+  meat?: FoodCategory;
+  fruit?: FoodCategory;
+  vegetables?: FoodCategory;
+  dairy?: FoodCategory;
+  other?: FoodCategory;
+  breakfastStyle?: string[];
+  breakfastItems?: string[];
+  lunchStyle?: string;
+  lunchDessert?: boolean;
+  lunchSnacks?: string;
+  dinnerStyle?: string;
+  dinnerDessert?: boolean;
+}
+
+export interface BeverageItem {
+  preferredBrand?: string;
+  qty?: number;
+  remarks?: string;
+}
+
+export interface BeveragePreferences {
+  warmBeverages?: string[];
+  warmBeveragesOther?: string;
+  sodas?: Record<string, BeverageItem>;
+  wines?: Record<string, BeverageItem>;
+  spirits?: Record<string, BeverageItem>;
+}
+
+export interface ActivityPreferences {
+  groupStyle?: 'active' | 'relaxed' | 'combination';
+  specificPlaces?: string;
+  activities?: string[];
+  healthNotes?: string;
+  sailingExperience?: string;
+}
+
+export interface SpecialRequests {
+  celebration?: string;
+  musicAtmosphere?: string;
+  petsOnBoard?: string;
+  extraNotes?: string;
+  emergencyContactName?: string;
+  emergencyContactPhone?: string;
+  emergencyContactRelation?: string;
+}
+
+export interface ClientPreparation {
+  token: string;
+  charterId: string;
+  lastSavedStep: number;
+  crew: CrewMember[];
+  travel: TravelLogistics;
+  activities: ActivityPreferences;
+  food: FoodPreferences;
+  beverages: BeveragePreferences;
+  special: SpecialRequests;
+  checklist: Record<string, boolean>;
+  createdAt: Timestamp | null;
+  updatedAt: Timestamp | null;
+  completedAt?: Timestamp | null;
+}
+
+// ---------------------------------------------------------------------------
+// Pre-departure checklist definition
+// ---------------------------------------------------------------------------
+
+export interface ChecklistCategory {
+  id: string;
+  label: string;
+  items: { id: string; label: string }[];
+}
+
+export const CHECKLIST_CATEGORIES: ChecklistCategory[] = [
+  {
+    id: 'documents',
+    label: 'Documents',
+    items: [
+      { id: 'doc-passport',      label: 'Passport valid for 6+ months beyond return date' },
+      { id: 'doc-insurance',     label: 'Travel insurance arranged and printed/saved' },
+      { id: 'doc-ehic',          label: 'European Health Insurance Card (EHIC)' },
+      { id: 'doc-prescriptions', label: 'Prescription medications with documentation' },
+      { id: 'doc-emergency',     label: 'Emergency contact details saved offline' },
+    ],
+  },
+  {
+    id: 'packing',
+    label: 'Clothing & Packing',
+    items: [
+      { id: 'pack-swimwear',     label: 'Swimwear (more than you think!)' },
+      { id: 'pack-deck-shoes',   label: 'Non-marking soft-sole deck shoes' },
+      { id: 'pack-layers',       label: 'Light layers for evenings underway' },
+      { id: 'pack-sun-hat',      label: 'Wide-brim sun hat' },
+      { id: 'pack-soft-bags',    label: 'Soft duffel bags only — no hard suitcases' },
+      { id: 'pack-sunscreen',    label: 'Reef-safe sunscreen SPF 50+' },
+      { id: 'pack-sunglasses',   label: 'Polarised sunglasses with strap' },
+    ],
+  },
+  {
+    id: 'health',
+    label: 'Health & Wellbeing',
+    items: [
+      { id: 'health-seasick',    label: 'Seasickness tablets or patches packed' },
+      { id: 'health-meds',       label: 'Sufficient personal medications for full trip' },
+      { id: 'health-dietary',    label: 'Dietary restrictions submitted to crew' },
+      { id: 'health-medical',    label: 'Medical needs confirmed with BlueOne' },
+    ],
+  },
+  {
+    id: 'electronics',
+    label: 'Electronics & Extras',
+    items: [
+      { id: 'elec-powerbank',    label: 'Power bank (sufficient charge for your days aboard)' },
+      { id: 'elec-camera',       label: 'Waterproof camera or phone case' },
+      { id: 'elec-adapter',      label: 'European power adapter (Type C/F)' },
+      { id: 'elec-reading',      label: 'Books or e-reader loaded for passages' },
+    ],
+  },
+  {
+    id: 'embarkation',
+    label: 'Day of Embarkation',
+    items: [
+      { id: 'day-time',          label: 'Embarkation time confirmed with BlueOne' },
+      { id: 'day-transport',     label: 'Transport to marina arranged' },
+      { id: 'day-cash',          label: 'Local cash (Euros) for small ports' },
+      { id: 'day-gps',           label: 'Marina name and GPS coordinates saved offline' },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Token generation
+// ---------------------------------------------------------------------------
+
+function generateClientSpaceToken(): string {
+  const bytes = new Uint8Array(24);
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < 24; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+// ---------------------------------------------------------------------------
+// Firestore operations
+// ---------------------------------------------------------------------------
+
+const COLLECTION = 'clientPreparations';
+
+function emptyPrep(token: string, charterId: string): Omit<ClientPreparation, 'createdAt' | 'updatedAt'> {
+  return {
+    token,
+    charterId,
+    lastSavedStep: 0,
+    crew: [],
+    travel: {},
+    activities: {},
+    food: {},
+    beverages: {},
+    special: {},
+    checklist: {},
+  };
+}
+
+export async function initClientSpace(charterId: string): Promise<string> {
+  const token = generateClientSpaceToken();
+  const ref = doc(db, COLLECTION, token);
+  await setDoc(ref, {
+    ...emptyPrep(token, charterId),
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  });
+  await updateCharter(charterId, { clientSpaceToken: token });
+  return token;
+}
+
+export async function getClientPreparation(token: string): Promise<ClientPreparation | null> {
+  const snap = await getDoc(doc(db, COLLECTION, token));
+  if (!snap.exists()) return null;
+  return { token, ...snap.data() } as ClientPreparation;
+}
+
+export async function getCharterByClientSpaceToken(token: string): Promise<Charter | null> {
+  const q = query(collection(db, 'availability'), where('clientSpaceToken', '==', token));
+  const snap = await getDocs(q);
+  if (snap.empty) return null;
+  const d = snap.docs[0];
+  return { id: d.id, ...d.data() } as import('./availability').Charter;
+}
+
+async function patchPrep(token: string, data: Record<string, unknown>): Promise<void> {
+  await updateDoc(doc(db, COLLECTION, token), {
+    ...data,
+    updatedAt: serverTimestamp(),
+  });
+}
+
+export async function saveCrew(token: string, crew: CrewMember[]): Promise<void> {
+  await patchPrep(token, { crew, lastSavedStep: Math.max(1, 0) });
+}
+
+export async function saveTravel(token: string, travel: TravelLogistics): Promise<void> {
+  await patchPrep(token, { travel });
+}
+
+export async function saveActivities(token: string, activities: ActivityPreferences): Promise<void> {
+  await patchPrep(token, { activities });
+}
+
+export async function saveFood(token: string, food: FoodPreferences): Promise<void> {
+  await patchPrep(token, { food });
+}
+
+export async function saveBeverages(token: string, beverages: BeveragePreferences): Promise<void> {
+  await patchPrep(token, { beverages });
+}
+
+export async function saveSpecial(token: string, special: SpecialRequests): Promise<void> {
+  await patchPrep(token, { special });
+}
+
+export async function saveChecklist(token: string, checklist: Record<string, boolean>): Promise<void> {
+  await updateDoc(doc(db, COLLECTION, token), { checklist, updatedAt: serverTimestamp() });
+}
+
+export async function saveStep(token: string, step: number): Promise<void> {
+  await updateDoc(doc(db, COLLECTION, token), { lastSavedStep: step, updatedAt: serverTimestamp() });
+}

--- a/lib/clientSpace.ts
+++ b/lib/clientSpace.ts
@@ -32,7 +32,24 @@ export interface CrewMember {
   medicalNotes?: string;
 }
 
+export interface TravelGroup {
+  id: string;
+  memberIndices: number[];
+  arrivalDate?: string;
+  arrivalTime?: string;
+  arrivalFlight?: string;
+  stayingAtHotel?: boolean;
+  hotelName?: string;
+  transferFromAirport?: boolean;
+  departureDate?: string;
+  departureTime?: string;
+  departureFlight?: string;
+  transferToAirport?: boolean;
+}
+
 export interface TravelLogistics {
+  groups?: TravelGroup[];
+  // Legacy flat fields (kept for backward compat)
   arrivalDate?: string;
   arrivalTime?: string;
   arrivalFlight?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3325,6 +3325,27 @@
         "tailwindcss": "4.3.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3390,6 +3411,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5284,6 +5313,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -8899,6 +8936,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -9873,6 +9921,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -9984,6 +10062,14 @@
       "peerDependencies": {
         "react": "^19.2.6"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-is-18": {
       "name": "react-is",
@@ -11734,7 +11820,7 @@
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3325,27 +3325,6 @@
         "tailwindcss": "4.3.0"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3411,14 +3390,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5313,14 +5284,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -8936,17 +8899,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -9921,36 +9873,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -10062,14 +9984,6 @@
       "peerDependencies": {
         "react": "^19.2.6"
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-is-18": {
       "name": "react-is",
@@ -11820,7 +11734,7 @@
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
Clients access a private, token-gated portal at /client-space/[token]
to complete their pre-trip preparation. Admins generate the unique link
per charter from the dashboard and share it with the client.

The 7-step form collects:
- Booking overview (read-only charter summary)
- Crew details: names, passport info, nationality, dietary & medical
- Travel & logistics: flights, arrival/departure times, hotel, transfers
- Activities & health: group style, interests, sailing experience
- Food preferences: per-category likes/dislikes, breakfast/lunch/dinner
- Beverages & bar: hot drinks, sodas, wines, spirits with quantities
- Special requests & interactive pre-departure checklist

Progress is persisted per-client in the new Firestore
`clientPreparations` collection (keyed by token). Each section
autosaves on "Save & Continue". Returning clients find all fields
pre-filled from Firestore.

https://claude.ai/code/session_014nrrtKzeoEDHbkXpunKkpW