### PR TITLE
Add on-board meal percentage tracking to food preferences

### DIFF
--- a/__tests__/client-space-summary.test.tsx
+++ b/__tests__/client-space-summary.test.tsx
@@ -519,6 +519,9 @@ describe('SummaryClient — Food section with data', () => {
       breakfastItems: ['Croissant', 'Yogurt'],
       lunchStyle: 'Light salads',
       dinnerStyle: 'Fine dining',
+      breakfastOnBoardPct: 100,
+      lunchOnBoardPct: 80,
+      dinnerOnBoardPct: 50,
     },
   };
 
@@ -555,10 +558,10 @@ describe('SummaryClient — Food section with data', () => {
     });
   });
 
-  it('renders Lunch & Dinner subsection', async () => {
+  it('renders Meals subsection', async () => {
     renderSummary();
     await waitFor(() => {
-      expect(screen.getByText('Lunch & Dinner')).toBeInTheDocument();
+      expect(screen.getByText('Meals')).toBeInTheDocument();
     });
   });
 
@@ -567,6 +570,18 @@ describe('SummaryClient — Food section with data', () => {
     await waitFor(() => {
       expect(screen.getByText('Light salads')).toBeInTheDocument();
     });
+  });
+
+  it('renders on-board percentage per meal', async () => {
+    renderSummary();
+    await waitFor(() => {
+      expect(screen.getByText('Breakfast on board')).toBeInTheDocument();
+    });
+    expect(screen.getByText('100%')).toBeInTheDocument();
+    expect(screen.getByText('Lunch on board')).toBeInTheDocument();
+    expect(screen.getByText('80%')).toBeInTheDocument();
+    expect(screen.getByText('Dinner on board')).toBeInTheDocument();
+    expect(screen.getByText('50%')).toBeInTheDocument();
   });
 });
 

--- a/__tests__/client-space.test.tsx
+++ b/__tests__/client-space.test.tsx
@@ -110,6 +110,7 @@ jest.mock('../lib/clientSpace', () => ({
   saveSnapshot: (...args: unknown[]) => mockSaveSnapshot(...args),
   getHistory: (...args: unknown[]) => mockGetHistory(...args),
   restoreSnapshot: (...args: unknown[]) => mockRestoreSnapshot(...args),
+  DEFAULT_ON_BOARD_PCT: { breakfast: 100, lunch: 80, dinner: 50 },
   CHECKLIST_CATEGORIES: [
     {
       id: 'documents',
@@ -446,14 +447,14 @@ describe('ClientSpaceClient — Step 4: Food Preferences', () => {
   });
 
   test('renders Breakfast section with style chips', () => {
-    expect(screen.getByText('Breakfast')).toBeInTheDocument();
+    expect(screen.getAllByText('Breakfast').length).toBeGreaterThan(0);
     expect(screen.getByRole('button', { name: /light \/ cold/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /american/i })).toBeInTheDocument();
   });
 
   test('renders Lunch and Dinner sections', () => {
-    expect(screen.getByText('Lunch')).toBeInTheDocument();
-    expect(screen.getByText('Dinner')).toBeInTheDocument();
+    expect(screen.getAllByText('Lunch').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Dinner').length).toBeGreaterThan(0);
   });
 
   test('Save Food Preferences calls saveFood', async () => {
@@ -464,6 +465,34 @@ describe('ClientSpaceClient — Step 4: Food Preferences', () => {
   test('Save creates snapshot with correct label', async () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save Food Preferences' }));
     await waitFor(() => expect(mockSaveSnapshot).toHaveBeenCalledWith(mockToken, expect.anything(), 'Food preferences'));
+  });
+
+  test('renders on-board percentage table with a row per meal', () => {
+    expect(screen.getByText('Meals on board')).toBeInTheDocument();
+    expect(screen.getByLabelText('Breakfast percent on board')).toBeInTheDocument();
+    expect(screen.getByLabelText('Lunch percent on board')).toBeInTheDocument();
+    expect(screen.getByLabelText('Dinner percent on board')).toBeInTheDocument();
+  });
+
+  test('defaults to Breakfast 100 / Lunch 80 / Dinner 50', () => {
+    expect(screen.getByLabelText('Breakfast percent on board')).toHaveValue(100);
+    expect(screen.getByLabelText('Lunch percent on board')).toHaveValue(80);
+    expect(screen.getByLabelText('Dinner percent on board')).toHaveValue(50);
+  });
+
+  test('entering a breakfast percentage saves breakfastOnBoardPct', async () => {
+    fireEvent.change(screen.getByLabelText('Breakfast percent on board'), { target: { value: '70' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Food Preferences' }));
+    await waitFor(() => expect(mockSaveFood).toHaveBeenCalledWith(
+      mockToken,
+      expect.objectContaining({ breakfastOnBoardPct: 70 }),
+    ));
+  });
+
+  test('percentage is clamped to a maximum of 100', () => {
+    const lunch = screen.getByLabelText('Lunch percent on board') as HTMLInputElement;
+    fireEvent.change(lunch, { target: { value: '150' } });
+    expect(lunch).toHaveValue(100);
   });
 });
 

--- a/app/client-space/[token]/ClientSpaceClient.tsx
+++ b/app/client-space/[token]/ClientSpaceClient.tsx
@@ -17,6 +17,7 @@ import {
   getHistory,
   restoreSnapshot,
   CHECKLIST_CATEGORIES,
+  DEFAULT_ON_BOARD_PCT,
   type ClientPreparation,
   type CrewMember,
   type TravelLogistics,
@@ -1218,13 +1219,64 @@ function ActivitiesStep({ initial, onSave, onAutoSave }: {
 // Step 4: Food preferences
 // ---------------------------------------------------------------------------
 
+function OnBoardPercentTable({ data, onChange }: {
+  data: Pick<FoodPreferences, 'breakfastOnBoardPct' | 'lunchOnBoardPct' | 'dinnerOnBoardPct'>;
+  onChange: (meal: 'breakfast' | 'lunch' | 'dinner', pct: number) => void;
+}) {
+  const rows: { key: 'breakfast' | 'lunch' | 'dinner'; label: string; value?: number }[] = [
+    { key: 'breakfast', label: 'Breakfast', value: data.breakfastOnBoardPct },
+    { key: 'lunch',     label: 'Lunch',     value: data.lunchOnBoardPct },
+    { key: 'dinner',    label: 'Dinner',    value: data.dinnerOnBoardPct },
+  ];
+  return (
+    <div className="border border-blue-100 rounded-lg p-2.5 bg-white/50">
+      <p className="text-[10px] font-bold text-blue-700 uppercase tracking-wide mb-1.5">Meals on board</p>
+      <p className="text-xs text-blue-500 mb-2">Roughly what share of each meal will be eaten on board? The rest we&apos;ll assume is ashore.</p>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-[10px] uppercase tracking-wide text-blue-500">
+            <th className="text-left font-bold pb-1">Meal</th>
+            <th className="text-left font-bold pb-1">% on board</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(r => (
+            <tr key={r.key} className="border-t border-blue-100">
+              <td className="py-1.5 text-blue-700 font-medium">{r.label}</td>
+              <td className="py-1.5">
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={5}
+                  value={r.value ?? ''}
+                  aria-label={`${r.label} percent on board`}
+                  onChange={e => onChange(r.key, Math.min(100, Math.max(0, Number(e.target.value) || 0)))}
+                  placeholder="e.g. 70"
+                  className="w-20 bg-white border border-blue-200 rounded-lg px-2 py-1 text-sm focus:outline-none focus:border-blue-400"
+                />
+                <span className="text-blue-400 text-xs ml-1">%</span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 function FoodStep({ initial, crew, onSave, onAutoSave }: {
   initial: FoodPreferences;
   crew: CrewMember[];
   onSave: (food: FoodPreferences) => Promise<void>;
   onAutoSave: (food: FoodPreferences) => Promise<void>;
 }) {
-  const [data, setData] = useState<FoodPreferences>(initial);
+  const [data, setData] = useState<FoodPreferences>(() => ({
+    ...initial,
+    breakfastOnBoardPct: initial.breakfastOnBoardPct ?? DEFAULT_ON_BOARD_PCT.breakfast,
+    lunchOnBoardPct: initial.lunchOnBoardPct ?? DEFAULT_ON_BOARD_PCT.lunch,
+    dinnerOnBoardPct: initial.dinnerOnBoardPct ?? DEFAULT_ON_BOARD_PCT.dinner,
+  }));
   const [saving, setSaving] = useState(false);
   const autoStatus = useAutoSave(data, onAutoSave);
 
@@ -1257,6 +1309,10 @@ function FoodStep({ initial, crew, onSave, onAutoSave }: {
     <div className="space-y-3">
       <SectionCard title="Food Preferences by Category" autoSave={autoStatus}>
         <p className="text-xs text-blue-500">Help us plan menus tailored to your group</p>
+        <OnBoardPercentTable
+          data={data}
+          onChange={(meal, pct) => set(`${meal}OnBoardPct` as keyof FoodPreferences, pct as never)}
+        />
         <div className="space-y-2">
           {FOOD_CATEGORIES.map(cat => {
             const key = cat.toLowerCase() as CatKey;

--- a/app/client-space/[token]/summary/SummaryClient.tsx
+++ b/app/client-space/[token]/summary/SummaryClient.tsx
@@ -353,7 +353,8 @@ function FoodSection({ prep }: { prep: ClientPreparation }) {
     return catData?.likes || catData?.dislikes || catData?.allergies;
   });
   const hasBreakfast = f.breakfastStyle?.length || f.breakfastItems?.length;
-  const hasMeals = f.lunchStyle || f.dinnerStyle;
+  const hasMeals = f.lunchStyle || f.dinnerStyle
+    || f.breakfastOnBoardPct != null || f.lunchOnBoardPct != null || f.dinnerOnBoardPct != null;
 
   return (
     <div className="summary-section border border-slate-200 rounded-xl overflow-hidden mb-4">
@@ -411,8 +412,11 @@ function FoodSection({ prep }: { prep: ClientPreparation }) {
 
       {hasMeals && (
         <>
-          <SubsectionTitle>Lunch & Dinner</SubsectionTitle>
+          <SubsectionTitle>Meals</SubsectionTitle>
           <div className="py-1">
+            <Row label="Breakfast on board" value={f.breakfastOnBoardPct != null ? `${f.breakfastOnBoardPct}%` : undefined} />
+            <Row label="Lunch on board" value={f.lunchOnBoardPct != null ? `${f.lunchOnBoardPct}%` : undefined} />
+            <Row label="Dinner on board" value={f.dinnerOnBoardPct != null ? `${f.dinnerOnBoardPct}%` : undefined} />
             <Row label="Lunch Style" value={f.lunchStyle} />
             <BoolRow label="Lunch Dessert" value={f.lunchDessert} />
             <Row label="Lunch Snacks" value={f.lunchSnacks} />

--- a/lib/clientSpace.ts
+++ b/lib/clientSpace.ts
@@ -90,7 +90,17 @@ export interface FoodPreferences {
   lunchSnacks?: string;
   dinnerStyle?: string;
   dinnerDessert?: boolean;
+  breakfastOnBoardPct?: number; // 0–100, % of this meal taken on board
+  lunchOnBoardPct?: number;     // 0–100
+  dinnerOnBoardPct?: number;    // 0–100
 }
+
+// Default share of each meal taken on board (remainder is ashore)
+export const DEFAULT_ON_BOARD_PCT = {
+  breakfast: 100,
+  lunch: 80,
+  dinner: 50,
+} as const;
 
 export interface BeverageItem {
   preferredBrand?: string;


### PR DESCRIPTION
## Summary
Adds the ability to track what percentage of each meal (breakfast, lunch, dinner) will be consumed on board versus ashore. This helps with menu planning and provisioning for yacht charters.

## Key Changes

- **New data fields** in `FoodPreferences` interface:
  - `breakfastOnBoardPct`, `lunchOnBoardPct`, `dinnerOnBoardPct` (0–100, optional)
  - Exported `DEFAULT_ON_BOARD_PCT` constant with sensible defaults (breakfast: 100%, lunch: 80%, dinner: 50%)

- **New UI component** `OnBoardPercentTable`:
  - Renders a styled table with input fields for each meal's on-board percentage
  - Enforces 0–100 range with clamping logic
  - Includes helpful label and description text

- **Food preferences form integration**:
  - Initializes percentage fields with defaults when not yet set
  - Wired up to auto-save and manual save flows
  - Percentage inputs are clamped to valid range on change

- **Summary display**:
  - Renamed "Lunch & Dinner" subsection to "Meals" to reflect broader scope
  - Displays on-board percentages for all three meals when present
  - Updated `hasMeals` logic to include percentage data

- **Test coverage**:
  - Added tests for table rendering and default values
  - Tests for percentage input changes and clamping behavior
  - Updated existing meal section tests to account for new table rows
  - Summary tests verify percentage display formatting

## Implementation Details

The percentage inputs use `step={5}` for convenient increments and include an `aria-label` for accessibility. The component follows the existing styling patterns with blue-themed borders and typography consistent with other food preference sections.

https://claude.ai/code/session_013pNrnbupC5ipw5sJAZyuxn